### PR TITLE
feat: Foundry agent spine — transcript → triaged Azure DevOps backlog (#62, #27)

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,70 @@
+# Preppie spine — transcript → triaged Azure DevOps backlog
+
+The meeting-to-backlog core. A transcript goes in; a well-triaged, deduped, hierarchical Azure
+DevOps backlog comes out. This is the implementation of the Azure AI Foundry migration (#62) and
+the "actually reason over the transcript" behaviour (#27).
+
+## Architecture
+
+```
+transcript.vtt
+   │  parse_vtt (speaker attribution preserved)
+   ▼
+run_spine ──────────────► Azure AI Foundry (Responses API, gpt-5-mini)
+   ▲  function calls          │  instructions compiled from the T-Minus-15 workitems SKILL
+   │  tool outputs            ▼
+Backend (deployed Azure Functions) ──► Azure DevOps work items
+   read_projects · search_work_items (dedupe) · create_work_item · link_work_items
+```
+
+**Why the Responses API + a thin loop (not a middleware service).** The earlier design used an
+OpenAI resource-level *assistant*, whose function calls surface as a `requires_action` run that a
+separate long-running handler must service — the "missing piece" the old docs describe. The Foundry
+agent here uses the **Responses API**: `run_spine` is a stateless loop that receives the model's
+function calls, calls the deployed backend, and feeds the results back. No extra deployed component.
+
+**Why instructions are compiled, not hand-written.** `build_instructions.py` pulls the canonical
+sections (six work item types, triage, title hygiene, dedupe, reply-back) straight out of the
+T-Minus-15 `workitems` SKILL and wraps them with this deployment's runtime contract. The methodology
+stays the single source of truth; regenerate when it changes.
+
+## Model & type mapping
+
+- Model: **gpt-5-mini** (see `config.py`). gpt-4o is not deployable on this subscription's quota;
+  gpt-5-mini is current-gen and strong at tool-calling. One-line swap via `PREPPIE_MODEL`.
+- The Agile process template has native Task, Bug, Issue, Epic, Feature, User Story but **no**
+  Enhancement/Risk/Question type, so those map to Task/Issue **+ a tag** (`Enhancement`, `Risk`,
+  `Question`) — filterable, no custom process required. Full table in `preppie_instructions.md`.
+
+## Run it
+
+```bash
+# one-time: compile the instructions from a checkout of T-Minus-15/claude-plugins
+SKILLS_DIR=/path/to/claude-plugins/skills python agent/build_instructions.py > agent/preppie_instructions.md
+
+# run the spine over a transcript (uses your `az login` identity; no keys)
+python -m agent.cli path/to/meeting.vtt
+```
+
+Configuration (all optional, see `config.py`): `PREPPIE_FOUNDRY_OPENAI_ENDPOINT`, `PREPPIE_MODEL`,
+`PREPPIE_API_VERSION`, `PREPPIE_BACKEND_URL`, `PREPPIE_PROJECT`, `PREPPIE_INSTRUCTIONS_PATH`.
+
+## Tests
+
+```bash
+python -m pytest agent/tests/ -q
+```
+
+The backend and the LLM client are injected, so the parser, tool dispatch, and the full tool loop
+(dedupe-before-create, result collection, termination) are tested with no network access.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `spine.py` | `parse_vtt`, `Backend` (tool dispatch), `run_spine` (the loop) — the testable core |
+| `build_instructions.py` | compiles the system prompt from the T-Minus-15 SKILLs |
+| `preppie_instructions.md` | the compiled instructions (committed artifact) |
+| `config.py` | env-overridable deployment settings |
+| `cli.py` | wires the real Azure client + backend and runs a transcript |
+| `tests/` | unit tests + the sample transcript fixture |

--- a/agent/build_instructions.py
+++ b/agent/build_instructions.py
@@ -49,7 +49,7 @@ and you follow the T-Minus-15 methodology below (these rules are compiled from t
 6. End with a reply-back roll-up table mapping each thing raised -> what you logged (see format).
 
 ## Runtime contract (this deployment)
-- Target project is **"Preppie"** in Azure DevOps org `ayush866`. Confirm with `read_projects`
+- Target project is **"{{PROJECT}}"** in Azure DevOps org `{{ORG}}`. Confirm with `read_projects`
   if unsure; do not assume any other project.
 - You act ONLY through the provided tools. Never fabricate work item IDs or URLs - use what the
   `create_work_item` tool returns.
@@ -86,6 +86,35 @@ hygiene) and any items you skipped as duplicates.
 """
 
 
+def neutralize_interactive_tools(text: str) -> str:
+    """Rewrite references to Claude-Code authoring tools out of the compiled instructions.
+
+    The methodology skills are written for a human-in-the-loop Claude Code session and mention tools
+    like `AskUserQuestion` / the `Task` subagent tool. The deployed runtime agent has NO such tools -
+    only the four backend function tools - so those references just make it waste turns trying to
+    call something that isn't there. Rewrite them into the runtime-appropriate behaviour: when unsure,
+    log a Question work item and surface it in the reply-back for humans to resolve. Applied at
+    compile time so regenerating the instructions can't reintroduce them.
+    """
+    # --- AskUserQuestion: the agent can't ask a human mid-run; it logs a Question instead. ---
+    # Sentence-level rewrites for the known phrasings, so the result still reads naturally.
+    text = re.sub(r"use\s+`AskUserQuestion`",
+                  "log it as a **Question** work item (and flag it in the reply-back)", text)
+    text = re.sub(r"\(`AskUserQuestion`\)",
+                  "(log it as a **Question** work item and flag it in the reply-back)", text)
+    # Catch-all for any remaining mention (bare or back-ticked).
+    text = text.replace("`AskUserQuestion`", "a **Question** work item")
+    text = text.replace("AskUserQuestion", "a Question work item")
+
+    # --- Task subagent: the methodology says to delegate transcript-reading to a `Task` subagent,
+    # but the runtime agent already has the full transcript in its prompt and no subagent tool, so
+    # rewrite those to "read it yourself". Order: specific phrasings first, then a catch-all. ---
+    text = re.sub(r"\s*[—-]\s*or delegate a sub-agent via `Task`\s*[—-]\s*", " ", text)
+    text = re.sub(r"\*\*delegate a sub-agent via `Task`\*\* to read it", "read it carefully", text)
+    text = re.sub(r"delegate a sub-agent via `Task`", "read the source material yourself", text)
+    return text
+
+
 def compile_instructions() -> str:
     parts = [HEADER, "\n---\n\n# Methodology (compiled from the T-Minus-15 skills)\n"]
     parts.append(section("workitems", "Safety rules (before you log anything)"))
@@ -95,7 +124,7 @@ def compile_instructions() -> str:
     parts.append(section("workitems", "Title hygiene (all types)"))
     parts.append(section("workitems", "Writing the description"))
     parts.append(section("workitems", "Reply-back convention (important)"))
-    return "\n\n".join(p.strip() for p in parts)
+    return neutralize_interactive_tools("\n\n".join(p.strip() for p in parts))
 
 
 if __name__ == "__main__":

--- a/agent/build_instructions.py
+++ b/agent/build_instructions.py
@@ -1,0 +1,102 @@
+"""
+Compile Preppie's agent instructions FROM the T-Minus-15 SKILL.md files.
+
+This is the heart of the Foundry migration (#62): the methodology is the source of truth, not a
+hand-maintained agent-config.json. We pull the canonical sections out of the `workitems` skill and
+wrap them with the deployment-specific runtime contract (tools, target project, the type ->
+Azure DevOps mapping for this process template, dedupe, hierarchy, reply-back, title hygiene).
+
+The T-Minus-15 skills live in a separate repo (T-Minus-15/claude-plugins). Point SKILLS_DIR at a
+checkout of it; the compiled result is committed alongside as `preppie_instructions.md` so the agent
+can be deployed without that checkout, and re-compiled whenever the methodology changes:
+
+    SKILLS_DIR=/path/to/claude-plugins/skills python agent/build_instructions.py > agent/preppie_instructions.md
+"""
+import os
+import re
+
+SKILLS = os.environ.get("SKILLS_DIR", os.path.expanduser("~/t-minus-15-claude-plugins/skills"))
+
+
+def section(skill: str, heading: str) -> str:
+    """Return the markdown block under a '## heading' (up to the next '## ') from a SKILL.md."""
+    path = os.path.join(SKILLS, skill, "SKILL.md")
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    text = re.sub(r"^---.*?---\n", "", text, count=1, flags=re.DOTALL)  # strip frontmatter
+    pat = re.compile(rf"^##\s+{re.escape(heading)}\s*$(.*?)(?=^##\s|\Z)", re.MULTILINE | re.DOTALL)
+    m = pat.search(text)
+    if not m:
+        raise SystemExit(f"[build] section '{heading}' not found in {skill}/SKILL.md")
+    return f"## {heading}\n{m.group(1).rstrip()}\n"
+
+
+HEADER = """# Preppie the Prepper - agent instructions
+
+You are **Preppie the Prepper**, the T-Minus-15 requirements/backlog agent. You turn a meeting
+transcript into a clean, well-triaged Azure DevOps backlog. You are precise, never invent facts,
+and you follow the T-Minus-15 methodology below (these rules are compiled from the T-Minus-15
+`workitems` skill and its per-type skills - they are the source of truth).
+
+## Your job for each run
+1. Read the transcript. Enumerate every actionable item raised, with who raised it and any owner.
+2. Triage each item to a type (see "The six work item types" + "Triage" below).
+3. Build the backlog structure (Epic -> Feature -> User Story) when the discussion implies it, and
+   attach the captured items under the right parent.
+4. BEFORE creating anything, DEDUPE: call `search_work_items` (titleContains) to check the item
+   doesn't already exist. Skip creation if a clear match exists; say so in your summary.
+5. Create each item with `create_work_item`, then link children to parents with `link_work_items`.
+6. End with a reply-back roll-up table mapping each thing raised -> what you logged (see format).
+
+## Runtime contract (this deployment)
+- Target project is **"Preppie"** in Azure DevOps org `ayush866`. Confirm with `read_projects`
+  if unsure; do not assume any other project.
+- You act ONLY through the provided tools. Never fabricate work item IDs or URLs - use what the
+  `create_work_item` tool returns.
+- **Type -> Azure DevOps mapping** (this project's Agile process template has native Task, Bug,
+  Issue, Epic, Feature, User Story - but NO native Enhancement/Risk/Question type). Map as:
+  | Triage type | `type` to pass | `tags` to pass |
+  |---|---|---|
+  | Task | `Task` | - |
+  | Bug | `Bug` | - |
+  | Issue | `Issue` | - |
+  | Enhancement | `Task` | `["Enhancement"]` |
+  | Risk | `Issue` | `["Risk"]` |
+  | Question | `Issue` | `["Question"]` |
+  | Epic / Feature / User Story | `Epic` / `Feature` / `User Story` | - |
+  Always set the tag when the mapping requires it, so the item stays filterable as its real type.
+- **Linking - attach to the nearest relevant parent.** Link every captured item to the MOST
+  specific parent that fits: a User Story if one applies, otherwise its Feature, otherwise the
+  Epic. A Bug/Task/Enhancement that affects a specific story must hang off that User Story, not the
+  Epic, when such a story exists.
+- Pass acceptance criteria ONLY on User Stories, via `acceptanceCriteria` (a list of strings), in
+  AMP form (Acceptance / Measure / Proof).
+- Keep descriptions rich enough that someone picking the item up cold understands it: what was
+  said, who raised it, why, and what "done" looks like. Never log a bare title.
+
+## Title hygiene (deployment-specific)
+- **Do NOT prefix a title with its type** ("Risk:", "Question:", "Bug:" ...). The work item type
+  and tag already convey that - the title states the thing itself.
+- Otherwise follow the "Title hygiene (all types)" rules below.
+
+## Output
+When all items are logged, output ONLY the reply-back summary described in "Reply-back convention"
+below: a one-line-per-item list, then the roll-up cross-reference table. Note any renames (title
+hygiene) and any items you skipped as duplicates.
+"""
+
+
+def compile_instructions() -> str:
+    parts = [HEADER, "\n---\n\n# Methodology (compiled from the T-Minus-15 skills)\n"]
+    parts.append(section("workitems", "Safety rules (before you log anything)"))
+    parts.append(section("workitems", "The six work item types"))
+    parts.append(section("workitems", "Triage: deciding the type"))
+    parts.append(section("workitems", "Capture flow (meetings & stand-ups)"))
+    parts.append(section("workitems", "Title hygiene (all types)"))
+    parts.append(section("workitems", "Writing the description"))
+    parts.append(section("workitems", "Reply-back convention (important)"))
+    return "\n\n".join(p.strip() for p in parts)
+
+
+if __name__ == "__main__":
+    print(compile_instructions())

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -23,6 +23,9 @@ def main(argv: list[str]) -> int:
     transcript = read_transcript(argv[1])
     with open(config.INSTRUCTIONS_PATH, encoding="utf-8") as f:
         instructions = f.read()
+    # Fill the deployment placeholders from config so what the model is told always matches the
+    # project the Backend is scope-locked to - PREPPIE_PROJECT/PREPPIE_ORG drive both.
+    instructions = instructions.replace("{{PROJECT}}", config.PROJECT).replace("{{ORG}}", config.ORG)
 
     token_provider = get_bearer_token_provider(DefaultAzureCredential(), config.TOKEN_SCOPE)
     client = AzureOpenAI(azure_endpoint=config.FOUNDRY_OPENAI_ENDPOINT,

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -1,0 +1,43 @@
+"""
+Run the Preppie spine over a transcript file:
+
+    python -m agent.cli path/to/meeting.vtt
+
+Authenticates to Azure AI Foundry with your `az login` identity (DefaultAzureCredential), so no
+keys are handled here. Reads deployment settings from agent/config.py (env-overridable).
+"""
+import sys
+
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from openai import AzureOpenAI
+
+from . import config
+from .spine import Backend, read_transcript, run_spine
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: python -m agent.cli <transcript.vtt>", file=sys.stderr)
+        return 2
+
+    transcript = read_transcript(argv[1])
+    with open(config.INSTRUCTIONS_PATH, encoding="utf-8") as f:
+        instructions = f.read()
+
+    token_provider = get_bearer_token_provider(DefaultAzureCredential(), config.TOKEN_SCOPE)
+    client = AzureOpenAI(azure_endpoint=config.FOUNDRY_OPENAI_ENDPOINT,
+                         azure_ad_token_provider=token_provider, api_version=config.API_VERSION)
+    backend = Backend(config.BACKEND_URL, config.PROJECT)
+
+    result = run_spine(transcript, instructions, client, backend, config.MODEL,
+                       on_event=lambda m: print(f"  [tool] {m}", flush=True))
+
+    print("\n===================== PREPPIE REPLY-BACK =====================\n")
+    print(result["reply_back"])
+    print(f"\n[summary] created {len(result['created'])} work items in '{config.PROJECT}' "
+          f"over {result['turns']} turns.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,26 @@
+"""Deployment configuration for the Preppie spine - all overridable via environment variables."""
+import os
+
+# Azure AI Foundry resource's Azure OpenAI endpoint (Responses API lives here).
+FOUNDRY_OPENAI_ENDPOINT = os.environ.get(
+    "PREPPIE_FOUNDRY_OPENAI_ENDPOINT", "https://preppie-foundry-ayush866.openai.azure.com/")
+
+# Model deployment name on that resource.
+MODEL = os.environ.get("PREPPIE_MODEL", "gpt-5-mini")
+
+# API version that exposes the Responses API.
+API_VERSION = os.environ.get("PREPPIE_API_VERSION", "2025-04-01-preview")
+
+# Deployed Azure Functions backend (the Azure DevOps tool surface).
+BACKEND_URL = os.environ.get(
+    "PREPPIE_BACKEND_URL", "https://preppie-backend-ayush866-prod.azurewebsites.net")
+
+# Target Azure DevOps project.
+PROJECT = os.environ.get("PREPPIE_PROJECT", "Preppie")
+
+# Compiled agent instructions (see build_instructions.py).
+INSTRUCTIONS_PATH = os.environ.get(
+    "PREPPIE_INSTRUCTIONS_PATH", os.path.join(os.path.dirname(__file__), "preppie_instructions.md"))
+
+# AAD scope for the Foundry data plane.
+TOKEN_SCOPE = os.environ.get("PREPPIE_TOKEN_SCOPE", "https://cognitiveservices.azure.com/.default")

--- a/agent/config.py
+++ b/agent/config.py
@@ -18,9 +18,18 @@ BACKEND_URL = os.environ.get(
 # Target Azure DevOps project.
 PROJECT = os.environ.get("PREPPIE_PROJECT", "Preppie")
 
+# Target Azure DevOps organization. This is informational only - it's interpolated into the compiled
+# instructions at load time (see cli.py) so the agent can name the right org in its reply-back. The
+# backend writes to the org from its OWN `AZURE_DEVOPS_ORG` setting, so keep PREPPIE_ORG in step with
+# that. (PROJECT is stronger: the same config.PROJECT both scope-locks the Backend and fills the
+# instructions - see cli.py - so those two genuinely cannot drift; ORG has no such cross-check.)
+ORG = os.environ.get("PREPPIE_ORG", "ayush866")
+
 # Compiled agent instructions (see build_instructions.py).
 INSTRUCTIONS_PATH = os.environ.get(
     "PREPPIE_INSTRUCTIONS_PATH", os.path.join(os.path.dirname(__file__), "preppie_instructions.md"))
 
-# AAD scope for the Foundry data plane.
+# AAD token scope for the Foundry data plane. The Foundry resource fronts its Responses API on the
+# Azure OpenAI / Cognitive Services endpoint, so the bearer token is minted for the Cognitive
+# Services scope (NOT https://ai.azure.com, which is the control-plane/management scope).
 TOKEN_SCOPE = os.environ.get("PREPPIE_TOKEN_SCOPE", "https://cognitiveservices.azure.com/.default")

--- a/agent/preppie_instructions.md
+++ b/agent/preppie_instructions.md
@@ -1,0 +1,141 @@
+# Preppie the Prepper - agent instructions
+
+You are **Preppie the Prepper**, the T-Minus-15 requirements/backlog agent. You turn a meeting
+transcript into a clean, well-triaged Azure DevOps backlog. You are precise, never invent facts,
+and you follow the T-Minus-15 methodology below (these rules are compiled from the T-Minus-15
+`workitems` skill and its per-type skills - they are the source of truth).
+
+## Your job for each run
+1. Read the transcript. Enumerate every actionable item raised, with who raised it and any owner.
+2. Triage each item to a type (see "The six work item types" + "Triage" below).
+3. Build the backlog structure (Epic -> Feature -> User Story) when the discussion implies it, and
+   attach the captured items under the right parent.
+4. BEFORE creating anything, DEDUPE: call `search_work_items` (titleContains) to check the item
+   doesn't already exist. Skip creation if a clear match exists; say so in your summary.
+5. Create each item with `create_work_item`, then link children to parents with `link_work_items`.
+6. End with a reply-back roll-up table mapping each thing raised -> what you logged (see format).
+
+## Runtime contract (this deployment)
+- Target project is **"Preppie"** in Azure DevOps org `ayush866`. Confirm with `read_projects`
+  if unsure; do not assume any other project.
+- You act ONLY through the provided tools. Never fabricate work item IDs or URLs - use what the
+  `create_work_item` tool returns.
+- **Type -> Azure DevOps mapping** (this project's Agile process template has native Task, Bug,
+  Issue, Epic, Feature, User Story - but NO native Enhancement/Risk/Question type). Map as:
+  | Triage type | `type` to pass | `tags` to pass |
+  |---|---|---|
+  | Task | `Task` | - |
+  | Bug | `Bug` | - |
+  | Issue | `Issue` | - |
+  | Enhancement | `Task` | `["Enhancement"]` |
+  | Risk | `Issue` | `["Risk"]` |
+  | Question | `Issue` | `["Question"]` |
+  | Epic / Feature / User Story | `Epic` / `Feature` / `User Story` | - |
+  Always set the tag when the mapping requires it, so the item stays filterable as its real type.
+- **Linking - attach to the nearest relevant parent.** Link every captured item to the MOST
+  specific parent that fits: a User Story if one applies, otherwise its Feature, otherwise the
+  Epic. A Bug/Task/Enhancement that affects a specific story must hang off that User Story, not the
+  Epic, when such a story exists.
+- Pass acceptance criteria ONLY on User Stories, via `acceptanceCriteria` (a list of strings), in
+  AMP form (Acceptance / Measure / Proof).
+- Keep descriptions rich enough that someone picking the item up cold understands it: what was
+  said, who raised it, why, and what "done" looks like. Never log a bare title.
+
+## Title hygiene (deployment-specific)
+- **Do NOT prefix a title with its type** ("Risk:", "Question:", "Bug:" ...). The work item type
+  and tag already convey that - the title states the thing itself.
+- Otherwise follow the "Title hygiene (all types)" rules below.
+
+## Output
+When all items are logged, output ONLY the reply-back summary described in "Reply-back convention"
+below: a one-line-per-item list, then the roll-up cross-reference table. Note any renames (title
+hygiene) and any items you skipped as duplicates.
+
+---
+
+# Methodology (compiled from the T-Minus-15 skills)
+
+## Safety rules (before you log anything)
+
+Logging into a shared tracker is easy to get wrong in ways that are hard to undo. Always:
+
+1. **Check before you create** — query the tracker first to avoid duplicate items. Duplicates cause confusion and waste effort.
+2. **Never hard-delete** — set state to "Removed"/closed instead. Deletion is irreversible and loses history.
+3. **Don't quietly amend an active Epic's backlog** — adding/removing Features on an Epic already underway changes the scope of in-progress work. Confirm with the requester (and, for client work, the customer) first.
+4. **Ask when unsure** — if you're not certain of the project, area path, owner, or whether something should be created at all, ask before acting (`AskUserQuestion`).
+
+## The six work item types
+
+| Type | Use for | Skill |
+|------|---------|-------|
+| **Task** | A concrete action/to-do with a clear owner | `task` |
+| **Bug** | Something is broken vs expected behaviour | `bug` |
+| **Enhancement** | Improve existing functionality | `enhancement` |
+| **Risk** | Something that *might* go wrong (impact + mitigation) | `risk` |
+| **Issue** | Something that *is* going wrong / a blocker (impact + resolution) | `issue` |
+| **Question** | A clarification needed before work can proceed (needs an owner) | `question` |
+
+(Epics, Features and User Stories are backlog structure — use the `epic`, `feature`, `user-story` skills for those.)
+
+## Triage: deciding the type
+
+For each item raised, ask:
+1. Is it broken right now? → **Bug** (or **Issue** if it's a process/delivery blocker rather than a code defect).
+2. Is it a "might happen" concern? → **Risk** (capture impact + mitigation).
+3. Is it "make the existing thing better"? → **Enhancement**.
+4. Is it an open question blocking progress? → **Question** (assign an owner).
+5. Otherwise, a plain action with an owner → **Task**.
+
+When the type is genuinely ambiguous, use `AskUserQuestion` rather than guessing.
+
+## Capture flow (meetings & stand-ups)
+
+1. **Read the source** — meeting chat, transcript, or notes. Enumerate each actionable item with who raised it and any owner mentioned.
+2. **Scope discipline** — only log the items you've been explicitly asked to. For items raised by *other* people, or where ownership is unclear, **flag and confirm before logging** — do not assume. ("These three are yours; I'll log them. Two others were raised by colleagues — want me to log those too?")
+3. **Decide the type** for each (triage above).
+4. **Sanitise the title** (see Title hygiene) — professional, client-safe wording.
+5. **Write a meaningful description** (see Writing the description). If the item was raised in a meeting, **read the meeting transcript / chat / notes** — or delegate a sub-agent via `Task` — to capture the context, decisions and acceptance detail, rather than logging a bare one-liner.
+6. **Log** each item in the tracker (title + description + owner + parent link).
+7. **Reply back** in the thread, and **summarise** to the requester (see Reply-back convention).
+
+## Title hygiene (all types)
+
+Every work item title must be **safe to share with a client** and professional, regardless of how it's created (including ad-hoc via `az boards`):
+- Rephrase internal slang/shorthand — "Chase X" → "Follow up X".
+- Prefer a **role or company** over an individual's personal name where possible.
+- Avoid HR/immigration/visa specifics, and commercially sensitive detail (rates, margins).
+- Keep it concise and outcome-oriented.
+
+If you change the wording from what was said, note it in the reply-back (so the requester can see "Chase HRB" was logged as "Follow up HRB").
+
+## Writing the description
+
+A work item is only useful if its description carries the context — **don't leave it blank or log just a title.**
+
+- **Aim for enough detail that someone picking it up cold understands it** — the background, what "done" looks like, and any links (related work items, documents, the PR/repo).
+- **Meeting-created items:** if it came out of a meeting or stand-up, **look at the transcript / chat / notes** to enrich the description — who asked for it, why, and any decisions or acceptance detail discussed. For a long transcript, **delegate a sub-agent via `Task`** to read it and draft the description, then review before logging.
+- **Match the type's fields** (see Per-type specifics) — a Bug needs repro steps; a Risk needs impact + mitigation; etc.
+- Keep it client-safe (same rules as titles).
+
+## Reply-back convention (important)
+
+After logging, do **two** reply-backs:
+
+**1. In the meeting thread / chat** — quote the person's original comment and reply with the linked item, so the action and its tracker entry sit together:
+
+> [Task 1234](https://dev.azure.com/<your-org>/<project>/_workitems/edit/1234): Create partnership document (`<project>`)
+
+Format: **`[<Type> <ID>](url): <Title> (<project>[ — assigned to <name>])`**, where `<Type> <ID>` is the hyperlink. Append the assignee when it's someone other than the requester.
+
+**2. Summarise back to the requester** — one line per item, then a roll-up table:
+
+> - **#1234 — Create partnership document** (Task, `<project>`, assigned to <name>, State: New) — [open](https://.../edit/1234)
+
+Roll-up + cross-reference table (so each thing raised maps to what was logged):
+
+> | Raised | Logged as | Link |
+> |---|---|---|
+> | Create partnership doc | Task **1234** | [edit/1234](https://.../edit/1234) |
+> | Chase supplier for quote | Task **1235** (titled "Follow up supplier quote") | [edit/1235](https://.../edit/1235) |
+
+Use ✅ to confirm an *action completed* ("Logged and posted ✅"), not as a per-item prefix.

--- a/agent/preppie_instructions.md
+++ b/agent/preppie_instructions.md
@@ -16,7 +16,7 @@ and you follow the T-Minus-15 methodology below (these rules are compiled from t
 6. End with a reply-back roll-up table mapping each thing raised -> what you logged (see format).
 
 ## Runtime contract (this deployment)
-- Target project is **"Preppie"** in Azure DevOps org `ayush866`. Confirm with `read_projects`
+- Target project is **"{{PROJECT}}"** in Azure DevOps org `{{ORG}}`. Confirm with `read_projects`
   if unsure; do not assume any other project.
 - You act ONLY through the provided tools. Never fabricate work item IDs or URLs - use what the
   `create_work_item` tool returns.
@@ -62,7 +62,7 @@ Logging into a shared tracker is easy to get wrong in ways that are hard to undo
 1. **Check before you create** — query the tracker first to avoid duplicate items. Duplicates cause confusion and waste effort.
 2. **Never hard-delete** — set state to "Removed"/closed instead. Deletion is irreversible and loses history.
 3. **Don't quietly amend an active Epic's backlog** — adding/removing Features on an Epic already underway changes the scope of in-progress work. Confirm with the requester (and, for client work, the customer) first.
-4. **Ask when unsure** — if you're not certain of the project, area path, owner, or whether something should be created at all, ask before acting (`AskUserQuestion`).
+4. **Ask when unsure** — if you're not certain of the project, area path, owner, or whether something should be created at all, ask before acting (log it as a **Question** work item and flag it in the reply-back).
 
 ## The six work item types
 
@@ -86,7 +86,7 @@ For each item raised, ask:
 4. Is it an open question blocking progress? → **Question** (assign an owner).
 5. Otherwise, a plain action with an owner → **Task**.
 
-When the type is genuinely ambiguous, use `AskUserQuestion` rather than guessing.
+When the type is genuinely ambiguous, log it as a **Question** work item (and flag it in the reply-back) rather than guessing.
 
 ## Capture flow (meetings & stand-ups)
 
@@ -94,7 +94,7 @@ When the type is genuinely ambiguous, use `AskUserQuestion` rather than guessing
 2. **Scope discipline** — only log the items you've been explicitly asked to. For items raised by *other* people, or where ownership is unclear, **flag and confirm before logging** — do not assume. ("These three are yours; I'll log them. Two others were raised by colleagues — want me to log those too?")
 3. **Decide the type** for each (triage above).
 4. **Sanitise the title** (see Title hygiene) — professional, client-safe wording.
-5. **Write a meaningful description** (see Writing the description). If the item was raised in a meeting, **read the meeting transcript / chat / notes** — or delegate a sub-agent via `Task` — to capture the context, decisions and acceptance detail, rather than logging a bare one-liner.
+5. **Write a meaningful description** (see Writing the description). If the item was raised in a meeting, **read the meeting transcript / chat / notes** to capture the context, decisions and acceptance detail, rather than logging a bare one-liner.
 6. **Log** each item in the tracker (title + description + owner + parent link).
 7. **Reply back** in the thread, and **summarise** to the requester (see Reply-back convention).
 
@@ -113,7 +113,7 @@ If you change the wording from what was said, note it in the reply-back (so the 
 A work item is only useful if its description carries the context — **don't leave it blank or log just a title.**
 
 - **Aim for enough detail that someone picking it up cold understands it** — the background, what "done" looks like, and any links (related work items, documents, the PR/repo).
-- **Meeting-created items:** if it came out of a meeting or stand-up, **look at the transcript / chat / notes** to enrich the description — who asked for it, why, and any decisions or acceptance detail discussed. For a long transcript, **delegate a sub-agent via `Task`** to read it and draft the description, then review before logging.
+- **Meeting-created items:** if it came out of a meeting or stand-up, **look at the transcript / chat / notes** to enrich the description — who asked for it, why, and any decisions or acceptance detail discussed. For a long transcript, read it carefully and draft the description, then review before logging.
 - **Match the type's fields** (see Per-type specifics) — a Bug needs repro steps; a Risk needs impact + mitigation; etc.
 - Keep it client-safe (same rules as titles).
 

--- a/agent/spine.py
+++ b/agent/spine.py
@@ -1,0 +1,199 @@
+"""
+Preppie spine - transcript -> Azure AI Foundry agent (Responses API) -> triaged Azure DevOps
+backlog, with dedupe.
+
+This is the meeting-to-backlog core (#27 + #62): the agent reasons over the transcript and drives
+the deployed backend tools. Tool-calling is a thin, stateless loop - no separate long-running
+middleware. Both the LLM client and the backend are injected, so the loop is unit-testable without
+network access (see tests/test_spine.py).
+"""
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+import urllib.error
+from typing import Any, Callable
+
+
+# ---------- transcript parsing ----------
+def parse_vtt(text: str) -> str:
+    """Flatten a WEBVTT transcript to 'Speaker: text' lines (drops cue numbers/timestamps)."""
+    lines = []
+    for raw in text.splitlines():
+        s = raw.strip()
+        if not s or s == "WEBVTT" or "-->" in s or s.isdigit():
+            continue
+        head, sep, tail = s.replace("<v ", "").partition(">")
+        if sep:  # had a <v Name> voice tag
+            lines.append(f"{head.strip()}: {tail.strip()}")
+        else:
+            lines.append(s)
+    return "\n".join(lines)
+
+
+def read_transcript(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    return parse_vtt(text) if path.lower().endswith(".vtt") else text
+
+
+# ---------- backend tool dispatch ----------
+class Backend:
+    """Calls the deployed Azure Functions backend. Every call is scoped to one project."""
+
+    def __init__(self, base_url: str, project: str, opener: Callable | None = None,
+                 attempts: int = 4):
+        self.base_url = base_url.rstrip("/")
+        self.project = project
+        self._opener = opener or urllib.request.urlopen
+        self._attempts = attempts
+
+    def _request(self, path: str, method: str, body: dict | None) -> dict:
+        # Retry transient connection blips and 5xx (Flex Consumption cold-scale can drop a
+        # connection); a single hiccup must not abort a whole meeting's backlog.
+        data = json.dumps(body).encode() if body is not None else None
+        for attempt in range(self._attempts):
+            req = urllib.request.Request(
+                f"{self.base_url}{path}", data=data, method=method,
+                headers={"Content-Type": "application/json"})
+            try:
+                with self._opener(req, timeout=45) as r:
+                    return json.loads(r.read().decode())
+            except urllib.error.HTTPError as e:
+                if e.code >= 500 and attempt < self._attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                return {"success": False, "error": f"HTTP {e.code}: {e.read().decode()[:300]}"}
+            except urllib.error.URLError as e:
+                if attempt < self._attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                return {"success": False, "error": f"connection error after {self._attempts} tries: {e}"}
+        return {"success": False, "error": "no request attempts made (attempts must be >= 1)"}
+
+    def dispatch(self, name: str, args: dict) -> dict:
+        """Route a tool call to the backend, injecting the project. Returns the backend JSON."""
+        if name == "read_projects":
+            return self._request("/api/read_projects", "GET", None)
+        if name == "search_work_items":
+            return self._request("/api/search_work_items", "POST", {**args, "project": self.project})
+        if name == "create_work_item":
+            return self._request("/api/create_work_item", "POST", {**args, "project": self.project})
+        if name == "link_work_items":
+            return self._request("/api/link_work_items", "POST", {**args, "project": self.project})
+        return {"success": False, "error": f"unknown tool {name}"}
+
+
+# ---------- tool schemas (match the deployed backend contract) ----------
+TOOLS: list[dict[str, Any]] = [
+    {"type": "function", "name": "read_projects",
+     "description": "List Azure DevOps projects in the org. Use to confirm the target project exists.",
+     "parameters": {"type": "object", "properties": {}, "required": []}},
+    {"type": "function", "name": "search_work_items",
+     "description": "Search existing work items in the target project. Use for DEDUPE before creating "
+                    "(titleContains), and to find a just-created parent.",
+     "parameters": {"type": "object", "properties": {
+         "titleContains": {"type": "string", "description": "Substring to match in the title."},
+         "workItemType": {"type": "string", "description": "Filter by type e.g. Task, Bug, Issue, Epic, Feature, User Story."},
+         "state": {"type": "string"},
+         "tags": {"type": "string", "description": "Substring to match in the item's tags (e.g. 'Risk')."},
+         "top": {"type": "integer"}}, "required": []}},
+    {"type": "function", "name": "create_work_item",
+     "description": "Create one work item in the target project. Returns its id and url. "
+                    "Apply the type->ADO mapping and tags from your instructions.",
+     "parameters": {"type": "object", "properties": {
+         "type": {"type": "string", "description": "Azure DevOps type: Task, Bug, Issue, Epic, Feature, or User Story."},
+         "title": {"type": "string", "description": "Clean, client-safe title (no type prefix)."},
+         "description": {"type": "string", "description": "Rich description: context, who raised it, definition of done."},
+         "acceptanceCriteria": {"type": "array", "items": {"type": "string"},
+                                 "description": "User Stories only. AMP form (Acceptance/Measure/Proof)."},
+         "tags": {"type": "array", "items": {"type": "string"},
+                  "description": "Triage tag when the native type differs, e.g. ['Enhancement'], ['Risk'], ['Question']."},
+         "priority": {"type": "integer", "description": "1 (highest) to 4."},
+         "estimatedEffort": {"type": "string", "description": "Optional effort/size estimate, e.g. '3', '5', '8'."}},
+         "required": ["type", "title", "description"]}},
+    {"type": "function", "name": "link_work_items",
+     "description": "Link a parent to child work items (parent-child hierarchy). "
+                    "sourceId = parent id, targetIds = child ids.",
+     "parameters": {"type": "object", "properties": {
+         "sourceId": {"type": "integer", "description": "Parent work item id."},
+         "targetIds": {"type": "array", "items": {"type": "integer"}, "description": "Child work item ids."},
+         "linkType": {"type": "string", "description": "Default System.LinkTypes.Hierarchy-Forward (parent->child)."}},
+         "required": ["sourceId", "targetIds"]}},
+]
+
+USER_PROMPT = (
+    "Process this meeting transcript into the backlog now. Dedupe before creating, build the "
+    "Epic/Feature/User Story structure, attach captured items under the nearest relevant parent, "
+    "and finish with the reply-back roll-up table.\n\n=== TRANSCRIPT ===\n"
+)
+
+
+def run_spine(transcript: str, instructions: str, client, backend: Backend, model: str,
+              *, on_event: Callable[[str], None] | None = None, max_turns: int = 30) -> dict:
+    """
+    Drive the Responses-API tool loop until the model stops calling tools.
+
+    `client` must expose `responses.create(...)` (an openai AzureOpenAI, or a fake in tests).
+    Returns {created: [...backend results...], reply_back: str, turns: int}.
+    """
+    def emit(msg: str) -> None:
+        if on_event:
+            on_event(msg)
+
+    resp = client.responses.create(
+        model=model, instructions=instructions,
+        input=[{"role": "user", "content": USER_PROMPT + transcript}], tools=TOOLS)
+
+    created: list[dict] = []
+    truncated = False
+    turns = 0
+    for turns in range(1, max_turns + 1):
+        calls = [o for o in resp.output if getattr(o, "type", None) == "function_call"]
+        if not calls:
+            break
+        outputs = []
+        for c in calls:
+            try:
+                args = json.loads(c.arguments or "{}")
+                if not isinstance(args, dict):
+                    raise ValueError(f"expected a JSON object, got {type(args).__name__}")
+            except (json.JSONDecodeError, ValueError) as e:
+                # A malformed tool call must not kill the whole run (and every call_id still
+                # needs a matching output, or the next Responses API call is invalid) - report
+                # it back to the model as a failed call and move on.
+                result = {"success": False, "error": f"malformed arguments for {c.name}: {e}"}
+                emit(f"BAD ARGS for {c.name}: {c.arguments!r} ({e})")
+                outputs.append({"type": "function_call_output", "call_id": c.call_id,
+                                 "output": json.dumps(result)})
+                continue
+            result = backend.dispatch(c.name, args)
+            if c.name == "create_work_item" and result.get("success"):
+                created.append(result)
+                emit(f"create {result['work_item_type']} #{result['work_item_id']}: {result['title']}")
+            elif c.name == "create_work_item":
+                emit(f"CREATE FAILED: {result.get('error')}")
+            elif c.name == "search_work_items":
+                emit(f"dedupe '{args.get('titleContains', '')}' -> {result.get('count', '?')} match(es)")
+            elif c.name == "link_work_items":
+                emit(f"link parent {args.get('sourceId')} -> {args.get('targetIds')}")
+            outputs.append({"type": "function_call_output", "call_id": c.call_id, "output": json.dumps(result)})
+        resp = client.responses.create(
+            model=model, instructions=instructions,
+            previous_response_id=resp.id, input=outputs, tools=TOOLS)
+    else:
+        # The for-loop ran out of turns without ever hitting the `break` above, i.e. the model
+        # was still calling tools when the budget ran out. The last resp we just got back may
+        # itself carry unserviced function_calls and therefore no real reply_back text - don't
+        # let that surface as a silent blank summary when items may already have been created.
+        pending = [o for o in resp.output if getattr(o, "type", None) == "function_call"]
+        if pending:
+            truncated = True
+            emit(f"max_turns ({max_turns}) reached with {len(pending)} pending tool call(s); stopping")
+
+    reply_back = resp.output_text
+    if truncated and not reply_back:
+        reply_back = (f"[Preppie stopped after {max_turns} turns without a final reply - "
+                       f"{len(created)} item(s) were created; check Azure DevOps directly.]")
+    return {"created": created, "reply_back": reply_back, "turns": turns}

--- a/agent/spine.py
+++ b/agent/spine.py
@@ -10,6 +10,7 @@ network access (see tests/test_spine.py).
 from __future__ import annotations
 
 import json
+import socket
 import time
 import urllib.request
 import urllib.error
@@ -59,17 +60,24 @@ class Backend:
                 headers={"Content-Type": "application/json"})
             try:
                 with self._opener(req, timeout=45) as r:
-                    return json.loads(r.read().decode())
+                    raw = r.read().decode()
+                return json.loads(raw)
             except urllib.error.HTTPError as e:
                 if e.code >= 500 and attempt < self._attempts - 1:
                     time.sleep(1.5 * (attempt + 1))
                     continue
                 return {"success": False, "error": f"HTTP {e.code}: {e.read().decode()[:300]}"}
-            except urllib.error.URLError as e:
+            except (urllib.error.URLError, socket.timeout, TimeoutError) as e:
+                # URLError covers connection failures; socket.timeout / TimeoutError covers a mid-body
+                # read timeout on r.read(), which is NOT wrapped in a URLError - both are transient, so
+                # retry rather than let the exception unwind and abort the whole run.
                 if attempt < self._attempts - 1:
                     time.sleep(1.5 * (attempt + 1))
                     continue
                 return {"success": False, "error": f"connection error after {self._attempts} tries: {e}"}
+            except (json.JSONDecodeError, ValueError) as e:
+                # A 2xx with a non-JSON body won't get better on retry - fail this call cleanly.
+                return {"success": False, "error": f"backend returned a non-JSON body: {e}"}
         return {"success": False, "error": "no request attempts made (attempts must be >= 1)"}
 
     def dispatch(self, name: str, args: dict) -> dict:
@@ -139,8 +147,13 @@ def run_spine(transcript: str, instructions: str, client, backend: Backend, mode
     Returns {created: [...backend results...], reply_back: str, turns: int}.
     """
     def emit(msg: str) -> None:
+        # A logging callback must never be able to derail the run (or, inside the dispatch
+        # try/except below, cause an already-created item to be reported back as failed).
         if on_event:
-            on_event(msg)
+            try:
+                on_event(msg)
+            except Exception:
+                pass
 
     resp = client.responses.create(
         model=model, instructions=instructions,
@@ -168,16 +181,25 @@ def run_spine(transcript: str, instructions: str, client, backend: Backend, mode
                 outputs.append({"type": "function_call_output", "call_id": c.call_id,
                                  "output": json.dumps(result)})
                 continue
-            result = backend.dispatch(c.name, args)
-            if c.name == "create_work_item" and result.get("success"):
-                created.append(result)
-                emit(f"create {result['work_item_type']} #{result['work_item_id']}: {result['title']}")
-            elif c.name == "create_work_item":
-                emit(f"CREATE FAILED: {result.get('error')}")
-            elif c.name == "search_work_items":
-                emit(f"dedupe '{args.get('titleContains', '')}' -> {result.get('count', '?')} match(es)")
-            elif c.name == "link_work_items":
-                emit(f"link parent {args.get('sourceId')} -> {args.get('targetIds')}")
+            try:
+                result = backend.dispatch(c.name, args)
+                if c.name == "create_work_item" and result.get("success"):
+                    created.append(result)
+                    emit(f"create {result.get('work_item_type', '?')} #{result.get('work_item_id', '?')}: "
+                         f"{result.get('title', '')}")
+                elif c.name == "create_work_item":
+                    emit(f"CREATE FAILED: {result.get('error')}")
+                elif c.name == "search_work_items":
+                    emit(f"dedupe '{args.get('titleContains', '')}' -> {result.get('count', '?')} match(es)")
+                elif c.name == "link_work_items":
+                    emit(f"link parent {args.get('sourceId')} -> {args.get('targetIds')}")
+            except Exception as e:
+                # Dispatch (or the result handling) must never take the whole run down: any raised
+                # exception here would leave this call_id unserviced, which also makes the NEXT
+                # Responses API call invalid. Report it back as a failed call and keep going - the
+                # same contract the malformed-arguments branch above upholds.
+                result = {"success": False, "error": f"tool {c.name} raised: {type(e).__name__}: {e}"}
+                emit(f"TOOL ERROR {c.name}: {type(e).__name__}: {e}")
             outputs.append({"type": "function_call_output", "call_id": c.call_id, "output": json.dumps(result)})
         resp = client.responses.create(
             model=model, instructions=instructions,

--- a/agent/tests/fixtures/sample-meeting.vtt
+++ b/agent/tests/fixtures/sample-meeting.vtt
@@ -1,0 +1,40 @@
+WEBVTT
+
+00:00:01.000 --> 00:00:08.200
+<v Priya Sharma>Okay, thanks for jumping on. The main thing I want to lock down today is the customer self-service portal for Q3. It's a big one — I'd call it our flagship initiative for the quarter.
+
+00:00:08.500 --> 00:00:15.000
+<v Daniel Okoro>Agreed. So at a high level the portal is the umbrella, and under it we've got at least the account management piece and the billing view. Those feel like two separate features to me.
+
+00:00:15.400 --> 00:00:24.800
+<v Priya Sharma>Right. For account management, the concrete thing customers keep asking for is: as a signed-in user I want to update my own contact details without raising a support ticket. That's a clear user story.
+
+00:00:25.100 --> 00:00:31.600
+<v Daniel Okoro>Makes sense. Given a logged-in user, when they change their email, then we send a confirmation link before it takes effect — otherwise we'll get account takeover complaints.
+
+00:00:32.000 --> 00:00:40.300
+<v Priya Sharma>Good, add that as the acceptance criteria. Now, separate thing — we already have a bug in the current portal. The session times out after about two minutes and dumps people back to login. It's been reported by three enterprise customers.
+
+00:00:40.700 --> 00:00:47.100
+<v Daniel Okoro>Yeah I've seen that one. It's the token refresh not firing. That's definitely a bug, not new work — we should log it and prioritise it high.
+
+00:00:47.500 --> 00:00:56.900
+<v Priya Sharma>One risk I want on the record: the billing view depends on the third-party invoicing API, and their rate limits are pretty aggressive. If we design the dashboard to call it live per page load, we could get throttled in production.
+
+00:00:57.300 --> 00:01:04.200
+<v Daniel Okoro>That's a real risk. We might need a caching layer. Actually — would it be worth caching invoices for, say, fifteen minutes? That'd cut the calls dramatically.
+
+00:01:04.600 --> 00:01:12.500
+<v Priya Sharma>That's a nice enhancement on top of the billing feature — let's capture it as an improvement rather than baking it into the core story for now.
+
+00:01:12.900 --> 00:01:21.400
+<v Daniel Okoro>One thing I'm genuinely unsure about: when we say "customers can manage their account", does that include deleting the account entirely? Because GDPR erasure is a whole separate workflow with legal sign-off.
+
+00:01:21.800 --> 00:01:29.000
+<v Priya Sharma>Good question — I don't have the answer. Let's flag that as an open question for legal before we scope the deletion flow. Don't guess at it.
+
+00:01:29.400 --> 00:01:36.700
+<v Daniel Okoro>Perfect. And a small task on my side — I'll set up the feature branch and the CI pipeline for the portal repo so we're ready to build. Nothing fancy, just the plumbing.
+
+00:01:37.000 --> 00:01:42.300
+<v Priya Sharma>Great. I think that's a solid backlog. Let's get it written up properly and we'll review it at standup tomorrow.

--- a/agent/tests/test_spine.py
+++ b/agent/tests/test_spine.py
@@ -1,6 +1,7 @@
 """Unit tests for the Preppie spine. No network: the backend and the LLM client are injected."""
 import json
 import os
+import socket
 import types
 
 from agent.spine import parse_vtt, read_transcript, Backend, run_spine
@@ -234,3 +235,102 @@ def test_run_spine_records_events():
                 ([], "ok")]
     run_spine("t", "i", _FakeClient(scripted), _FakeBackend(), "m", on_event=events.append)
     assert any("create Task" in e for e in events)
+
+
+# ---------- run-loop robustness: a tool that raises must not abort the run ----------
+def test_run_spine_continues_when_dispatch_raises():
+    """A raised exception from dispatch must not kill the run: the call_id still gets a failed
+    output (or the next Responses API call is invalid), and the run reaches its final reply."""
+    class _RaisingBackend:
+        def dispatch(self, name, args):
+            raise RuntimeError("boom")
+
+    scripted = [
+        ([_fcall("create_work_item", {"type": "Task", "title": "T", "description": "d"}, "c1")], ""),
+        ([], "done despite the error"),
+    ]
+    client = _FakeClient(scripted)
+    result = run_spine("t", "i", client, _RaisingBackend(), "m")
+
+    assert result["reply_back"] == "done despite the error"
+    assert result["created"] == []  # nothing recorded as created
+    fed_back = client.calls[1]["input"]
+    assert fed_back[0]["call_id"] == "c1"
+    out = json.loads(fed_back[0]["output"])
+    assert out["success"] is False and "raised" in out["error"]
+
+
+def test_run_spine_survives_missing_result_keys():
+    """A create reported as success but missing work_item_type/id/title must not KeyError the run."""
+    class _ThinBackend:
+        def dispatch(self, name, args):
+            return {"success": True}  # no work_item_type / work_item_id / title
+
+    scripted = [
+        ([_fcall("create_work_item", {"type": "Task", "title": "T", "description": "d"}, "c1")], ""),
+        ([], "ok"),
+    ]
+    result = run_spine("t", "i", _FakeClient(scripted), _ThinBackend(), "m")
+    assert result["reply_back"] == "ok"
+    assert len(result["created"]) == 1  # still counted (success is true), just no crash
+
+
+# ---------- _request robustness: non-JSON body and read timeout ----------
+def test_backend_non_json_body_fails_cleanly():
+    """A 2xx with a non-JSON body must return a failure dict, not raise out of dispatch."""
+    class _BadResp:
+        def read(self):
+            return b"<html>not json</html>"
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    out = Backend("https://b", "P", opener=lambda req, timeout=None: _BadResp()).dispatch("read_projects", {})
+    assert out["success"] is False and "non-JSON" in out["error"]
+
+
+def test_backend_retries_read_timeout(monkeypatch):
+    """A socket.timeout (mid-body read timeout, not a URLError) is transient and must be retried."""
+    monkeypatch.setattr("agent.spine.time.sleep", lambda *_: None)
+    n = {"calls": 0}
+
+    def flaky(req, timeout=None):
+        n["calls"] += 1
+        if n["calls"] < 2:
+            raise socket.timeout("read timed out")
+        return _FakeResp({"success": True, "count": 0})
+
+    out = Backend("https://b", "P", opener=flaky).dispatch("search_work_items", {})
+    assert out["success"] is True and n["calls"] == 2
+
+
+# ---------- compiled instructions must not reference tools the runtime agent lacks ----------
+def test_compiled_instructions_have_no_authoring_tool_refs():
+    """The deployed agent has ONLY the four backend function tools - no Claude-Code authoring tools
+    (AskUserQuestion, the Task subagent). Those methodology references must be stripped from the
+    committed instructions, or the agent wastes turns trying to call tools it doesn't have. Guards
+    against a new phrasing leaking in on the next regeneration."""
+    import agent.config as config
+    txt = open(config.INSTRUCTIONS_PATH, encoding="utf-8").read()
+    assert "AskUserQuestion" not in txt
+    assert "sub-agent via `Task`" not in txt
+    assert "subagent via `Task`" not in txt
+
+
+def test_neutralize_interactive_tools_rewrites_all_known_forms():
+    """Unit-level cover for the compile-time rewriter, independent of the SKILL.md source text."""
+    from agent.build_instructions import neutralize_interactive_tools
+    src = (
+        "If unsure, use `AskUserQuestion` here. Ask before acting (`AskUserQuestion`). "
+        "Read the notes — or delegate a sub-agent via `Task` — to capture context. "
+        "For a long transcript, **delegate a sub-agent via `Task`** to read it and draft it."
+    )
+    out = neutralize_interactive_tools(src)
+    assert "AskUserQuestion" not in out
+    assert "`Task`" not in out
+    assert "sub-agent" not in out
+    assert "read it carefully" in out
+    assert "**Question** work item" in out

--- a/agent/tests/test_spine.py
+++ b/agent/tests/test_spine.py
@@ -1,0 +1,236 @@
+"""Unit tests for the Preppie spine. No network: the backend and the LLM client are injected."""
+import json
+import os
+import types
+
+from agent.spine import parse_vtt, read_transcript, Backend, run_spine
+
+
+# ---------- transcript parsing ----------
+def test_parse_vtt_extracts_speakers():
+    vtt = ("WEBVTT\n\n1\n00:00:01.000 --> 00:00:03.000\n<v Alice>Hello there\n\n"
+           "00:00:04.000 --> 00:00:05.000\n<v Bob>Hi Alice\n")
+    assert parse_vtt(vtt) == "Alice: Hello there\nBob: Hi Alice"
+
+
+def test_parse_vtt_keeps_untagged_lines_and_drops_noise():
+    assert parse_vtt("WEBVTT\n\n2\n00:00:01.000 --> 00:00:02.000\nplain line\n") == "plain line"
+
+
+def test_read_transcript_plain_file_is_verbatim(tmp_path):
+    p = tmp_path / "notes.txt"
+    p.write_text("Alice: just do it")
+    assert read_transcript(str(p)) == "Alice: just do it"
+
+
+def test_sample_fixture_parses():
+    fixture = os.path.join(os.path.dirname(__file__), "fixtures", "sample-meeting.vtt")
+    out = read_transcript(fixture)
+    assert "Priya Sharma:" in out and "Daniel Okoro:" in out and "-->" not in out
+
+
+# ---------- backend dispatch ----------
+class _FakeResp:
+    def __init__(self, body):
+        self._b = json.dumps(body).encode()
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_backend_dispatch_injects_project_and_posts():
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["body"] = json.loads(req.data.decode()) if req.data else None
+        return _FakeResp({"success": True, "count": 0})
+
+    Backend("https://backend.example/", "MyProj", opener=opener).dispatch(
+        "search_work_items", {"titleContains": "foo"})
+    assert seen["url"].endswith("/api/search_work_items")
+    assert seen["method"] == "POST"
+    assert seen["body"] == {"project": "MyProj", "titleContains": "foo"}
+
+
+def test_backend_read_projects_is_get_no_body():
+    def opener(req, timeout=None):
+        assert req.get_method() == "GET"
+        assert req.data is None
+        return _FakeResp({"success": True, "projects": []})
+
+    Backend("https://b", "P", opener=opener).dispatch("read_projects", {})
+
+
+def test_backend_retries_transient_connection_error(monkeypatch):
+    import urllib.error
+    monkeypatch.setattr("agent.spine.time.sleep", lambda *_: None)  # no real backoff in tests
+    calls = {"n": 0}
+
+    def flaky_opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise urllib.error.URLError("connection refused")
+        return _FakeResp({"success": True, "count": 0})
+
+    out = Backend("https://b", "P", opener=flaky_opener).dispatch("search_work_items", {})
+    assert out["success"] is True and calls["n"] == 3  # failed twice, succeeded on the third
+
+
+def test_backend_gives_up_after_attempts(monkeypatch):
+    import urllib.error
+    monkeypatch.setattr("agent.spine.time.sleep", lambda *_: None)
+
+    def always_refuse(req, timeout=None):
+        raise urllib.error.URLError("refused")
+
+    out = Backend("https://b", "P", opener=always_refuse, attempts=3).dispatch("read_projects", {})
+    assert out["success"] is False and "connection error" in out["error"]
+
+
+def test_backend_dispatch_project_cannot_be_overridden_by_args():
+    # The backend's guarantee is that every call is scoped to Backend.project. If the model's
+    # tool-call arguments ever contained a stray "project" key, it must not win over that.
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["body"] = json.loads(req.data.decode())
+        return _FakeResp({"success": True})
+
+    Backend("https://b", "RealProject", opener=opener).dispatch(
+        "create_work_item", {"type": "Task", "title": "t", "description": "d", "project": "Hijacked"})
+    assert seen["body"]["project"] == "RealProject"
+
+
+# ---------- the run loop ----------
+def _fcall(name, args, call_id):
+    return types.SimpleNamespace(type="function_call", name=name,
+                                 arguments=json.dumps(args), call_id=call_id)
+
+
+class _FakeClient:
+    """Replays a scripted list of (output_items, output_text) responses."""
+
+    def __init__(self, scripted):
+        self._scripted = list(scripted)
+        self._n = 0
+        self.calls = []
+        self.responses = self
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        out, text = self._scripted[self._n]
+        self._n += 1
+        return types.SimpleNamespace(output=out, output_text=text, id=f"resp_{self._n}")
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.dispatched = []
+        self._next_id = 100
+
+    def dispatch(self, name, args):
+        self.dispatched.append((name, args))
+        if name == "create_work_item":
+            self._next_id += 1
+            return {"success": True, "work_item_id": self._next_id,
+                    "work_item_type": args["type"], "title": args["title"], "url": "http://x"}
+        if name == "search_work_items":
+            return {"success": True, "count": 0, "workItems": []}
+        return {"success": True}
+
+
+def test_run_spine_dedupes_before_create_and_collects_results():
+    scripted = [
+        ([_fcall("search_work_items", {"titleContains": "Portal"}, "c1"),
+          _fcall("create_work_item", {"type": "Epic", "title": "Portal", "description": "d"}, "c2")], ""),
+        ([], "done: logged 1 item"),
+    ]
+    client, backend = _FakeClient(scripted), _FakeBackend()
+    result = run_spine("Alice: build a portal", "INSTR", client, backend, "gpt-x")
+
+    names = [n for n, _ in backend.dispatched]
+    assert names.index("search_work_items") < names.index("create_work_item")  # dedupe first
+    assert len(result["created"]) == 1
+    assert result["created"][0]["title"] == "Portal"
+    assert result["reply_back"] == "done: logged 1 item"
+    # tool outputs were fed back referencing the prior response id
+    assert client.calls[1].get("previous_response_id") == "resp_1"
+
+
+def test_run_spine_terminates_at_max_turns():
+    forever = ([_fcall("search_work_items", {}, "c")], "")
+    result = run_spine("t", "i", _FakeClient([forever] * 50), _FakeBackend(), "m", max_turns=5)
+    assert result["turns"] == 5
+    # the model never produced a final text reply (it kept calling tools) - the caller must still
+    # get a non-blank explanation rather than silently seeing an empty reply-back.
+    assert result["reply_back"] and "5 turns" in result["reply_back"]
+
+
+def test_run_spine_handles_malformed_tool_arguments_without_crashing():
+    scripted = [
+        ([types.SimpleNamespace(type="function_call", name="create_work_item",
+                                arguments="{not valid json", call_id="c1")], ""),
+        ([], "done"),
+    ]
+    client, backend = _FakeClient(scripted), _FakeBackend()
+    result = run_spine("t", "i", client, backend, "m")
+    # the bad call must never reach the backend, but the loop must still feed an output back
+    # (referencing the same call_id) so the model isn't left hanging, and the run completes.
+    assert backend.dispatched == []
+    assert result["reply_back"] == "done"
+    second_call_outputs = client.calls[1]["input"]
+    assert second_call_outputs[0]["call_id"] == "c1"
+    assert json.loads(second_call_outputs[0]["output"])["success"] is False
+
+
+def test_run_spine_handles_non_object_tool_arguments():
+    scripted = [
+        ([types.SimpleNamespace(type="function_call", name="search_work_items",
+                                arguments="[1, 2, 3]", call_id="c1")], ""),
+        ([], "done"),
+    ]
+    result = run_spine("t", "i", _FakeClient(scripted), _FakeBackend(), "m")
+    assert result["reply_back"] == "done"
+
+
+class _FailingCreateBackend:
+    """A backend whose create_work_item always fails, to check the loop doesn't leave the model
+    hanging (every call_id still needs a function_call_output) or lose track of the run."""
+
+    def __init__(self):
+        self.dispatched = []
+
+    def dispatch(self, name, args):
+        self.dispatched.append((name, args))
+        return {"success": False, "error": "Azure DevOps rejected the request"}
+
+
+def test_run_spine_feeds_output_back_after_failed_create():
+    scripted = [
+        ([_fcall("create_work_item", {"type": "Task", "title": "T", "description": "d"}, "c1")], ""),
+        ([], "done: 0 items logged"),
+    ]
+    client = _FakeClient(scripted)
+    result = run_spine("t", "i", client, _FailingCreateBackend(), "m")
+
+    assert result["created"] == []  # nothing to show for a failed create
+    assert result["reply_back"] == "done: 0 items logged"  # the loop still completed normally
+    fed_back = client.calls[1]["input"]
+    assert fed_back[0]["call_id"] == "c1"
+    assert json.loads(fed_back[0]["output"])["success"] is False
+
+
+def test_run_spine_records_events():
+    events = []
+    scripted = [([_fcall("create_work_item", {"type": "Task", "title": "T", "description": "d"}, "c1")], ""),
+                ([], "ok")]
+    run_spine("t", "i", _FakeClient(scripted), _FakeBackend(), "m", on_event=events.append)
+    assert any("create Task" in e for e in events)

--- a/src/function_app.py
+++ b/src/function_app.py
@@ -292,6 +292,22 @@ def create_work_item(req: func.HttpRequest) -> func.HttpResponse:
         tags = req_body.get("tags") or []
         if isinstance(tags, str):
             tags = [t.strip() for t in tags.split(";") if t.strip()]
+        elif isinstance(tags, list):
+            # A list of non-strings would blow up later at "; ".join(tags) as a 500. Validate up
+            # front and return a clear 400 instead.
+            if not all(isinstance(t, str) for t in tags):
+                return func.HttpResponse(
+                    json.dumps({"error": "Invalid 'tags': must be a string or a list of strings"}),
+                    status_code=400,
+                    mimetype="application/json"
+                )
+            tags = [t.strip() for t in tags if t.strip()]
+        else:
+            return func.HttpResponse(
+                json.dumps({"error": "Invalid 'tags': must be a string or a list of strings"}),
+                status_code=400,
+                mimetype="application/json"
+            )
         custom_fields = {}
 
         # Get DevOps client and create work item

--- a/src/function_app.py
+++ b/src/function_app.py
@@ -287,8 +287,11 @@ def create_work_item(req: func.HttpRequest) -> func.HttpResponse:
                 mimetype="application/json"
             )
 
-        # Extract metadata from description if present (speaker, timestamp, meeting ID)
-        tags = []
+        # Tags carry the T-Minus-15 triage type when the process template has no native
+        # work item type for it (e.g. Enhancement -> Task+tag, Risk/Question -> Issue+tag).
+        tags = req_body.get("tags") or []
+        if isinstance(tags, str):
+            tags = [t.strip() for t in tags.split(";") if t.strip()]
         custom_fields = {}
 
         # Get DevOps client and create work item


### PR DESCRIPTION
## Summary

Adds the meeting-to-backlog **spine**: a transcript goes in, and a triaged, deduped, hierarchical
Azure DevOps backlog comes out. From the sample two-speaker transcript it produces an Epic → two
Features → a User Story (with AMP acceptance criteria), plus a Bug, Risk, Enhancement, Question and
Task — each triaged to the right type and linked to the nearest parent — then replies back with a
raised→logged-as roll-up table.

```
transcript.vtt → parse → Foundry agent (Responses API, gpt-5-mini) ⇄ backend tools → work items
                          instructions compiled from the T-Minus-15 `workitems` SKILL
```

## Issues Addressed

### Fixes #62 — Azure AI Foundry migration
Runs the agent on Azure AI Foundry via the **Responses API**, so tool-calling is a thin stateless
loop (model → function call → backend → result back) with no separate long-running `requires_action`
handler to deploy — the "missing piece" the current docs describe.

### Fixes #27 — transcript → triaged Azure DevOps backlog
Parses the transcript, builds the Epic/Feature/User Story hierarchy with the six T-Minus-15 capture
types, dedupes before creating, links to the nearest parent, and replies back with a roll-up table.

### Does NOT fix (scope discipline — separate PRs)
- **#30** — posting the reply-back into the Teams thread (follow-up)
- Infra **Y1 → Flex Consumption** fix — PR #79
- **Pennie → Preppie** rename — PR #80

## Key decisions (calling these out for review)

1. **Azure AI Foundry + the Responses API, not the resource-level OpenAI assistant.** The assistant
   pattern surfaces tool calls as a `requires_action` run that a separate long-running handler must
   service — the "missing piece" the current docs describe. The Responses API lets `run_spine` be a
   **thin stateless loop** (model → function call → backend → result back), so there's no extra
   deployed component. This is the #62 migration, done in a way that also closes #27.

2. **Instructions are compiled from the SKILL, not hand-written.** `build_instructions.py` pulls the
   canonical sections (six types, triage, title hygiene, dedupe, reply-back) out of the T-Minus-15
   `workitems` skill and wraps them with the deployment's runtime contract. The methodology stays
   the source of truth; `agent-config.json`'s hand-maintained instructions are superseded.

3. **Model: gpt-5-mini.** gpt-4o is not deployable on this subscription's quota (the Standard SKU is
   retired for new deployments and the GlobalStandard interactive bucket is 0). gpt-5-mini is
   current-gen, strong at tool-calling, and cheaper. One-line swap via `PREPPIE_MODEL`.

4. **Type → Azure DevOps mapping via tags.** The Agile process template has no native
   Enhancement/Risk/Question type, so those map to Task/Issue **+ a tag** — filterable, no custom
   process template needed. (The `workitems` SKILL explicitly prescribes "use a label" here.)

5. **Dedupe from the first write.** "Check before you create" is the SKILL's safety rule #1, so
   `search_work_items` runs before every create — not a later add-on.

## Key Changes

- `agent/spine.py` — the testable core: transcript parse, backend tool dispatch (with project
  scope-lock + retry/backoff), and the stateless Responses-API tool loop.
- `agent/build_instructions.py` + `agent/preppie_instructions.md` — compile the agent's system
  prompt from the T-Minus-15 `workitems` SKILL (superseding hand-maintained instructions).
- `agent/config.py`, `agent/cli.py` — env-driven config and `python -m agent.cli <vtt>` entrypoint.
- `src/function_app.py` — `create_work_item` now reads `tags` from the request (was hardcoded
  `tags = []`), so the type→tag mapping reaches Azure DevOps. Backwards compatible (absent → no tags).
- `agent/tests/test_spine.py` — 15 unit tests, backend + LLM client injected (no network).

## Robustness

- The tool loop tolerates a failed/errored tool call: it feeds a `{success:false}` result back for
  that `call_id` so the Responses API contract is preserved and the run continues rather than
  aborting a whole meeting's backlog.
- Malformed tool-call arguments are caught (not crash-inducing).
- The backend client retries transient connection blips and 5xx with backoff.
- The project scope is injected server-side of the merge, so a stray `project` arg can't retarget
  another project.

## Known limitations / follow-up

Dedupe is **phrasing-sensitive**: it matches by title substring, so an item reworded from an
existing one can miss the match. Fine for the single-meeting flow here; a semantic/multi-keyword
dedupe is noted as future work.

## Test Plan

- [x] `python -m pytest agent/tests/ -q` → **15 passing**, no network (parser, tool dispatch with
      project injection + scope-lock, and the full loop: dedupe-before-create, malformed-arg
      handling, failed-create continuation, max-turn truncation, retry/give-up).
- [x] Verified end-to-end against the live Foundry agent + deployed backend — produces the full
      Epic → Feature → User Story backlog with tags and AMP acceptance criteria, deduped and linked,
      plus the reply-back roll-up table.

```bash
python -m pytest agent/tests/ -q
python -m agent.cli agent/tests/fixtures/sample-meeting.vtt   # uses your az login; no keys
```

## Note on CI

The red checks are **fork-PR limits, not this code**: the Claude review action can't get an OIDC
token on PRs from forks, and `test.yml`'s "Comment PR" step can't post from a fork's read-only
token. The actual build/lint/test jobs pass.

## Screenshots — sample run (board #29–#40)

**Hierarchy** — Feature → User Story → Task, with effort points and the `Enhancement` tag, in the Features backlog view:
<img width="1708" alt="Feature hierarchy" src="https://github.com/user-attachments/assets/f5e47713-7fb4-47e7-8ffb-6eab6eca3a95" />

**All 12 items** — every capture type with the right icon and tags (`Risk`, `Question`, `Enhancement`):
<img width="1707" alt="Work items" src="https://github.com/user-attachments/assets/2be8caa8-b27b-4fee-aac9-9b4a95cc9287" />

**Written up properly** — User Story #32 with AMP acceptance criteria (Acceptance / Measure / Proof), parent + child links, and traceability to who raised it — not a transcript dump:
<img width="1710" alt="User Story 32" src="https://github.com/user-attachments/assets/811d446f-6f40-4faf-a621-462ca68fd1a9" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

