### PR TITLE
feat(agent): fetch Teams meeting transcripts from Microsoft Graph (post-meeting capture)

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,70 @@
+# Preppie spine — transcript → triaged Azure DevOps backlog
+
+The meeting-to-backlog core. A transcript goes in; a well-triaged, deduped, hierarchical Azure
+DevOps backlog comes out. This is the implementation of the Azure AI Foundry migration (#62) and
+the "actually reason over the transcript" behaviour (#27).
+
+## Architecture
+
+```
+transcript.vtt
+   │  parse_vtt (speaker attribution preserved)
+   ▼
+run_spine ──────────────► Azure AI Foundry (Responses API, gpt-5-mini)
+   ▲  function calls          │  instructions compiled from the T-Minus-15 workitems SKILL
+   │  tool outputs            ▼
+Backend (deployed Azure Functions) ──► Azure DevOps work items
+   read_projects · search_work_items (dedupe) · create_work_item · link_work_items
+```
+
+**Why the Responses API + a thin loop (not a middleware service).** The earlier design used an
+OpenAI resource-level *assistant*, whose function calls surface as a `requires_action` run that a
+separate long-running handler must service — the "missing piece" the old docs describe. The Foundry
+agent here uses the **Responses API**: `run_spine` is a stateless loop that receives the model's
+function calls, calls the deployed backend, and feeds the results back. No extra deployed component.
+
+**Why instructions are compiled, not hand-written.** `build_instructions.py` pulls the canonical
+sections (six work item types, triage, title hygiene, dedupe, reply-back) straight out of the
+T-Minus-15 `workitems` SKILL and wraps them with this deployment's runtime contract. The methodology
+stays the single source of truth; regenerate when it changes.
+
+## Model & type mapping
+
+- Model: **gpt-5-mini** (see `config.py`). gpt-4o is not deployable on this subscription's quota;
+  gpt-5-mini is current-gen and strong at tool-calling. One-line swap via `PREPPIE_MODEL`.
+- The Agile process template has native Task, Bug, Issue, Epic, Feature, User Story but **no**
+  Enhancement/Risk/Question type, so those map to Task/Issue **+ a tag** (`Enhancement`, `Risk`,
+  `Question`) — filterable, no custom process required. Full table in `preppie_instructions.md`.
+
+## Run it
+
+```bash
+# one-time: compile the instructions from a checkout of T-Minus-15/claude-plugins
+SKILLS_DIR=/path/to/claude-plugins/skills python agent/build_instructions.py > agent/preppie_instructions.md
+
+# run the spine over a transcript (uses your `az login` identity; no keys)
+python -m agent.cli path/to/meeting.vtt
+```
+
+Configuration (all optional, see `config.py`): `PREPPIE_FOUNDRY_OPENAI_ENDPOINT`, `PREPPIE_MODEL`,
+`PREPPIE_API_VERSION`, `PREPPIE_BACKEND_URL`, `PREPPIE_PROJECT`, `PREPPIE_INSTRUCTIONS_PATH`.
+
+## Tests
+
+```bash
+python -m pytest agent/tests/ -q
+```
+
+The backend and the LLM client are injected, so the parser, tool dispatch, and the full tool loop
+(dedupe-before-create, result collection, termination) are tested with no network access.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `spine.py` | `parse_vtt`, `Backend` (tool dispatch), `run_spine` (the loop) — the testable core |
+| `build_instructions.py` | compiles the system prompt from the T-Minus-15 SKILLs |
+| `preppie_instructions.md` | the compiled instructions (committed artifact) |
+| `config.py` | env-overridable deployment settings |
+| `cli.py` | wires the real Azure client + backend and runs a transcript |
+| `tests/` | unit tests + the sample transcript fixture |

--- a/agent/build_instructions.py
+++ b/agent/build_instructions.py
@@ -1,0 +1,102 @@
+"""
+Compile Preppie's agent instructions FROM the T-Minus-15 SKILL.md files.
+
+This is the heart of the Foundry migration (#62): the methodology is the source of truth, not a
+hand-maintained agent-config.json. We pull the canonical sections out of the `workitems` skill and
+wrap them with the deployment-specific runtime contract (tools, target project, the type ->
+Azure DevOps mapping for this process template, dedupe, hierarchy, reply-back, title hygiene).
+
+The T-Minus-15 skills live in a separate repo (T-Minus-15/claude-plugins). Point SKILLS_DIR at a
+checkout of it; the compiled result is committed alongside as `preppie_instructions.md` so the agent
+can be deployed without that checkout, and re-compiled whenever the methodology changes:
+
+    SKILLS_DIR=/path/to/claude-plugins/skills python agent/build_instructions.py > agent/preppie_instructions.md
+"""
+import os
+import re
+
+SKILLS = os.environ.get("SKILLS_DIR", os.path.expanduser("~/t-minus-15-claude-plugins/skills"))
+
+
+def section(skill: str, heading: str) -> str:
+    """Return the markdown block under a '## heading' (up to the next '## ') from a SKILL.md."""
+    path = os.path.join(SKILLS, skill, "SKILL.md")
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    text = re.sub(r"^---.*?---\n", "", text, count=1, flags=re.DOTALL)  # strip frontmatter
+    pat = re.compile(rf"^##\s+{re.escape(heading)}\s*$(.*?)(?=^##\s|\Z)", re.MULTILINE | re.DOTALL)
+    m = pat.search(text)
+    if not m:
+        raise SystemExit(f"[build] section '{heading}' not found in {skill}/SKILL.md")
+    return f"## {heading}\n{m.group(1).rstrip()}\n"
+
+
+HEADER = """# Preppie the Prepper - agent instructions
+
+You are **Preppie the Prepper**, the T-Minus-15 requirements/backlog agent. You turn a meeting
+transcript into a clean, well-triaged Azure DevOps backlog. You are precise, never invent facts,
+and you follow the T-Minus-15 methodology below (these rules are compiled from the T-Minus-15
+`workitems` skill and its per-type skills - they are the source of truth).
+
+## Your job for each run
+1. Read the transcript. Enumerate every actionable item raised, with who raised it and any owner.
+2. Triage each item to a type (see "The six work item types" + "Triage" below).
+3. Build the backlog structure (Epic -> Feature -> User Story) when the discussion implies it, and
+   attach the captured items under the right parent.
+4. BEFORE creating anything, DEDUPE: call `search_work_items` (titleContains) to check the item
+   doesn't already exist. Skip creation if a clear match exists; say so in your summary.
+5. Create each item with `create_work_item`, then link children to parents with `link_work_items`.
+6. End with a reply-back roll-up table mapping each thing raised -> what you logged (see format).
+
+## Runtime contract (this deployment)
+- Target project is **"Preppie"** in Azure DevOps org `ayush866`. Confirm with `read_projects`
+  if unsure; do not assume any other project.
+- You act ONLY through the provided tools. Never fabricate work item IDs or URLs - use what the
+  `create_work_item` tool returns.
+- **Type -> Azure DevOps mapping** (this project's Agile process template has native Task, Bug,
+  Issue, Epic, Feature, User Story - but NO native Enhancement/Risk/Question type). Map as:
+  | Triage type | `type` to pass | `tags` to pass |
+  |---|---|---|
+  | Task | `Task` | - |
+  | Bug | `Bug` | - |
+  | Issue | `Issue` | - |
+  | Enhancement | `Task` | `["Enhancement"]` |
+  | Risk | `Issue` | `["Risk"]` |
+  | Question | `Issue` | `["Question"]` |
+  | Epic / Feature / User Story | `Epic` / `Feature` / `User Story` | - |
+  Always set the tag when the mapping requires it, so the item stays filterable as its real type.
+- **Linking - attach to the nearest relevant parent.** Link every captured item to the MOST
+  specific parent that fits: a User Story if one applies, otherwise its Feature, otherwise the
+  Epic. A Bug/Task/Enhancement that affects a specific story must hang off that User Story, not the
+  Epic, when such a story exists.
+- Pass acceptance criteria ONLY on User Stories, via `acceptanceCriteria` (a list of strings), in
+  AMP form (Acceptance / Measure / Proof).
+- Keep descriptions rich enough that someone picking the item up cold understands it: what was
+  said, who raised it, why, and what "done" looks like. Never log a bare title.
+
+## Title hygiene (deployment-specific)
+- **Do NOT prefix a title with its type** ("Risk:", "Question:", "Bug:" ...). The work item type
+  and tag already convey that - the title states the thing itself.
+- Otherwise follow the "Title hygiene (all types)" rules below.
+
+## Output
+When all items are logged, output ONLY the reply-back summary described in "Reply-back convention"
+below: a one-line-per-item list, then the roll-up cross-reference table. Note any renames (title
+hygiene) and any items you skipped as duplicates.
+"""
+
+
+def compile_instructions() -> str:
+    parts = [HEADER, "\n---\n\n# Methodology (compiled from the T-Minus-15 skills)\n"]
+    parts.append(section("workitems", "Safety rules (before you log anything)"))
+    parts.append(section("workitems", "The six work item types"))
+    parts.append(section("workitems", "Triage: deciding the type"))
+    parts.append(section("workitems", "Capture flow (meetings & stand-ups)"))
+    parts.append(section("workitems", "Title hygiene (all types)"))
+    parts.append(section("workitems", "Writing the description"))
+    parts.append(section("workitems", "Reply-back convention (important)"))
+    return "\n\n".join(p.strip() for p in parts)
+
+
+if __name__ == "__main__":
+    print(compile_instructions())

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -1,26 +1,79 @@
 """
-Run the Preppie spine over a transcript file:
+Run the Preppie spine over a transcript:
 
-    python -m agent.cli path/to/meeting.vtt
+    python -m agent.cli path/to/meeting.vtt                       # local file (unchanged)
+    python -m agent.cli https://teams.microsoft.com/l/meetup-join/...   # live Teams meeting
+
+If the argument looks like a Teams meeting join URL (or PREPPIE_MEETING_URL is set in the
+environment), the transcript is fetched live from Microsoft Graph via agent.transcript_fetch,
+using the PREPPIE_GRAPH_* credentials in agent/config.py. Otherwise the argument is read as a
+local .vtt/.txt file, exactly as before. The Graph import is lazy/guarded so a local-file run
+never requires Graph to be configured.
 
 Authenticates to Azure AI Foundry with your `az login` identity (DefaultAzureCredential), so no
 keys are handled here. Reads deployment settings from agent/config.py (env-overridable).
 """
+import os
 import sys
 
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from openai import AzureOpenAI
 
 from . import config
-from .spine import Backend, read_transcript, run_spine
+from .spine import Backend, parse_vtt, read_transcript, run_spine
+
+MEETING_URL_PREFIX = "https://teams.microsoft.com/"
+
+
+def _is_meeting_url(arg: str) -> bool:
+    return isinstance(arg, str) and arg.startswith(MEETING_URL_PREFIX)
+
+
+def _resolve_transcript(arg: str, *, explicit_arg: bool = True) -> str:
+    """Resolve the flattened transcript text for either input mode. Prints which mode is used.
+
+    `explicit_arg` is True when the caller actually passed argv[1] (as opposed to `arg` being an
+    empty placeholder because no argv was given at all - see main()). An explicit, non-meeting-URL
+    argv always wins over PREPPIE_MEETING_URL: the env var must not silently redirect a run the
+    user pointed at a specific local file.
+    """
+    env_meeting_url = os.environ.get("PREPPIE_MEETING_URL")
+
+    if explicit_arg and not _is_meeting_url(arg):
+        if env_meeting_url:
+            print(f"[warning] PREPPIE_MEETING_URL is set but ignored in favor of the explicit "
+                  f"argument {arg!r}", file=sys.stderr)
+        print(f"[mode] local transcript file: {arg}")
+        return read_transcript(arg)
+
+    meeting_url = arg if _is_meeting_url(arg) else env_meeting_url
+    if meeting_url:
+        print(f"[mode] live Teams meeting via Microsoft Graph: {meeting_url}")
+        # Lazy import: a local-.vtt-file run must work even when Graph isn't configured at all.
+        from .transcript_fetch import fetch_meeting_vtt
+        vtt = fetch_meeting_vtt(
+            config.GRAPH_TENANT_ID, config.GRAPH_CLIENT_ID, config.GRAPH_CLIENT_SECRET,
+            config.GRAPH_ORGANIZER_USER_ID, meeting_url)
+        return parse_vtt(vtt)
+
+    print(f"[mode] local transcript file: {arg}")
+    return read_transcript(arg)
 
 
 def main(argv: list[str]) -> int:
-    if len(argv) < 2:
-        print("usage: python -m agent.cli <transcript.vtt>", file=sys.stderr)
+    meeting_url_env = os.environ.get("PREPPIE_MEETING_URL")
+    explicit_arg = len(argv) >= 2
+    if not explicit_arg and not meeting_url_env:
+        print("usage: python -m agent.cli <transcript.vtt | Teams meeting join URL>", file=sys.stderr)
         return 2
 
-    transcript = read_transcript(argv[1])
+    arg = argv[1] if explicit_arg else ""
+    try:
+        transcript = _resolve_transcript(arg, explicit_arg=explicit_arg)
+    except Exception as e:
+        print(f"error: could not fetch/read transcript: {e}", file=sys.stderr)
+        return 1
+
     with open(config.INSTRUCTIONS_PATH, encoding="utf-8") as f:
         instructions = f.read()
 

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -1,0 +1,43 @@
+"""
+Run the Preppie spine over a transcript file:
+
+    python -m agent.cli path/to/meeting.vtt
+
+Authenticates to Azure AI Foundry with your `az login` identity (DefaultAzureCredential), so no
+keys are handled here. Reads deployment settings from agent/config.py (env-overridable).
+"""
+import sys
+
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from openai import AzureOpenAI
+
+from . import config
+from .spine import Backend, read_transcript, run_spine
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: python -m agent.cli <transcript.vtt>", file=sys.stderr)
+        return 2
+
+    transcript = read_transcript(argv[1])
+    with open(config.INSTRUCTIONS_PATH, encoding="utf-8") as f:
+        instructions = f.read()
+
+    token_provider = get_bearer_token_provider(DefaultAzureCredential(), config.TOKEN_SCOPE)
+    client = AzureOpenAI(azure_endpoint=config.FOUNDRY_OPENAI_ENDPOINT,
+                         azure_ad_token_provider=token_provider, api_version=config.API_VERSION)
+    backend = Backend(config.BACKEND_URL, config.PROJECT)
+
+    result = run_spine(transcript, instructions, client, backend, config.MODEL,
+                       on_event=lambda m: print(f"  [tool] {m}", flush=True))
+
+    print("\n===================== PREPPIE REPLY-BACK =====================\n")
+    print(result["reply_back"])
+    print(f"\n[summary] created {len(result['created'])} work items in '{config.PROJECT}' "
+          f"over {result['turns']} turns.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/agent/config.py
+++ b/agent/config.py
@@ -24,3 +24,10 @@ INSTRUCTIONS_PATH = os.environ.get(
 
 # AAD scope for the Foundry data plane.
 TOKEN_SCOPE = os.environ.get("PREPPIE_TOKEN_SCOPE", "https://cognitiveservices.azure.com/.default")
+
+# Microsoft Graph app-only auth (client-credentials), for fetching a Teams meeting transcript
+# directly from a join URL instead of a local .vtt file - see agent/transcript_fetch.py.
+GRAPH_TENANT_ID = os.environ.get("PREPPIE_GRAPH_TENANT_ID", "")
+GRAPH_CLIENT_ID = os.environ.get("PREPPIE_GRAPH_CLIENT_ID", "")
+GRAPH_CLIENT_SECRET = os.environ.get("PREPPIE_GRAPH_CLIENT_SECRET", "")
+GRAPH_ORGANIZER_USER_ID = os.environ.get("PREPPIE_GRAPH_ORGANIZER_USER_ID", "")

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,26 @@
+"""Deployment configuration for the Preppie spine - all overridable via environment variables."""
+import os
+
+# Azure AI Foundry resource's Azure OpenAI endpoint (Responses API lives here).
+FOUNDRY_OPENAI_ENDPOINT = os.environ.get(
+    "PREPPIE_FOUNDRY_OPENAI_ENDPOINT", "https://preppie-foundry-ayush866.openai.azure.com/")
+
+# Model deployment name on that resource.
+MODEL = os.environ.get("PREPPIE_MODEL", "gpt-5-mini")
+
+# API version that exposes the Responses API.
+API_VERSION = os.environ.get("PREPPIE_API_VERSION", "2025-04-01-preview")
+
+# Deployed Azure Functions backend (the Azure DevOps tool surface).
+BACKEND_URL = os.environ.get(
+    "PREPPIE_BACKEND_URL", "https://preppie-backend-ayush866-prod.azurewebsites.net")
+
+# Target Azure DevOps project.
+PROJECT = os.environ.get("PREPPIE_PROJECT", "Preppie")
+
+# Compiled agent instructions (see build_instructions.py).
+INSTRUCTIONS_PATH = os.environ.get(
+    "PREPPIE_INSTRUCTIONS_PATH", os.path.join(os.path.dirname(__file__), "preppie_instructions.md"))
+
+# AAD scope for the Foundry data plane.
+TOKEN_SCOPE = os.environ.get("PREPPIE_TOKEN_SCOPE", "https://cognitiveservices.azure.com/.default")

--- a/agent/preppie_instructions.md
+++ b/agent/preppie_instructions.md
@@ -1,0 +1,141 @@
+# Preppie the Prepper - agent instructions
+
+You are **Preppie the Prepper**, the T-Minus-15 requirements/backlog agent. You turn a meeting
+transcript into a clean, well-triaged Azure DevOps backlog. You are precise, never invent facts,
+and you follow the T-Minus-15 methodology below (these rules are compiled from the T-Minus-15
+`workitems` skill and its per-type skills - they are the source of truth).
+
+## Your job for each run
+1. Read the transcript. Enumerate every actionable item raised, with who raised it and any owner.
+2. Triage each item to a type (see "The six work item types" + "Triage" below).
+3. Build the backlog structure (Epic -> Feature -> User Story) when the discussion implies it, and
+   attach the captured items under the right parent.
+4. BEFORE creating anything, DEDUPE: call `search_work_items` (titleContains) to check the item
+   doesn't already exist. Skip creation if a clear match exists; say so in your summary.
+5. Create each item with `create_work_item`, then link children to parents with `link_work_items`.
+6. End with a reply-back roll-up table mapping each thing raised -> what you logged (see format).
+
+## Runtime contract (this deployment)
+- Target project is **"Preppie"** in Azure DevOps org `ayush866`. Confirm with `read_projects`
+  if unsure; do not assume any other project.
+- You act ONLY through the provided tools. Never fabricate work item IDs or URLs - use what the
+  `create_work_item` tool returns.
+- **Type -> Azure DevOps mapping** (this project's Agile process template has native Task, Bug,
+  Issue, Epic, Feature, User Story - but NO native Enhancement/Risk/Question type). Map as:
+  | Triage type | `type` to pass | `tags` to pass |
+  |---|---|---|
+  | Task | `Task` | - |
+  | Bug | `Bug` | - |
+  | Issue | `Issue` | - |
+  | Enhancement | `Task` | `["Enhancement"]` |
+  | Risk | `Issue` | `["Risk"]` |
+  | Question | `Issue` | `["Question"]` |
+  | Epic / Feature / User Story | `Epic` / `Feature` / `User Story` | - |
+  Always set the tag when the mapping requires it, so the item stays filterable as its real type.
+- **Linking - attach to the nearest relevant parent.** Link every captured item to the MOST
+  specific parent that fits: a User Story if one applies, otherwise its Feature, otherwise the
+  Epic. A Bug/Task/Enhancement that affects a specific story must hang off that User Story, not the
+  Epic, when such a story exists.
+- Pass acceptance criteria ONLY on User Stories, via `acceptanceCriteria` (a list of strings), in
+  AMP form (Acceptance / Measure / Proof).
+- Keep descriptions rich enough that someone picking the item up cold understands it: what was
+  said, who raised it, why, and what "done" looks like. Never log a bare title.
+
+## Title hygiene (deployment-specific)
+- **Do NOT prefix a title with its type** ("Risk:", "Question:", "Bug:" ...). The work item type
+  and tag already convey that - the title states the thing itself.
+- Otherwise follow the "Title hygiene (all types)" rules below.
+
+## Output
+When all items are logged, output ONLY the reply-back summary described in "Reply-back convention"
+below: a one-line-per-item list, then the roll-up cross-reference table. Note any renames (title
+hygiene) and any items you skipped as duplicates.
+
+---
+
+# Methodology (compiled from the T-Minus-15 skills)
+
+## Safety rules (before you log anything)
+
+Logging into a shared tracker is easy to get wrong in ways that are hard to undo. Always:
+
+1. **Check before you create** — query the tracker first to avoid duplicate items. Duplicates cause confusion and waste effort.
+2. **Never hard-delete** — set state to "Removed"/closed instead. Deletion is irreversible and loses history.
+3. **Don't quietly amend an active Epic's backlog** — adding/removing Features on an Epic already underway changes the scope of in-progress work. Confirm with the requester (and, for client work, the customer) first.
+4. **Ask when unsure** — if you're not certain of the project, area path, owner, or whether something should be created at all, ask before acting (`AskUserQuestion`).
+
+## The six work item types
+
+| Type | Use for | Skill |
+|------|---------|-------|
+| **Task** | A concrete action/to-do with a clear owner | `task` |
+| **Bug** | Something is broken vs expected behaviour | `bug` |
+| **Enhancement** | Improve existing functionality | `enhancement` |
+| **Risk** | Something that *might* go wrong (impact + mitigation) | `risk` |
+| **Issue** | Something that *is* going wrong / a blocker (impact + resolution) | `issue` |
+| **Question** | A clarification needed before work can proceed (needs an owner) | `question` |
+
+(Epics, Features and User Stories are backlog structure — use the `epic`, `feature`, `user-story` skills for those.)
+
+## Triage: deciding the type
+
+For each item raised, ask:
+1. Is it broken right now? → **Bug** (or **Issue** if it's a process/delivery blocker rather than a code defect).
+2. Is it a "might happen" concern? → **Risk** (capture impact + mitigation).
+3. Is it "make the existing thing better"? → **Enhancement**.
+4. Is it an open question blocking progress? → **Question** (assign an owner).
+5. Otherwise, a plain action with an owner → **Task**.
+
+When the type is genuinely ambiguous, use `AskUserQuestion` rather than guessing.
+
+## Capture flow (meetings & stand-ups)
+
+1. **Read the source** — meeting chat, transcript, or notes. Enumerate each actionable item with who raised it and any owner mentioned.
+2. **Scope discipline** — only log the items you've been explicitly asked to. For items raised by *other* people, or where ownership is unclear, **flag and confirm before logging** — do not assume. ("These three are yours; I'll log them. Two others were raised by colleagues — want me to log those too?")
+3. **Decide the type** for each (triage above).
+4. **Sanitise the title** (see Title hygiene) — professional, client-safe wording.
+5. **Write a meaningful description** (see Writing the description). If the item was raised in a meeting, **read the meeting transcript / chat / notes** — or delegate a sub-agent via `Task` — to capture the context, decisions and acceptance detail, rather than logging a bare one-liner.
+6. **Log** each item in the tracker (title + description + owner + parent link).
+7. **Reply back** in the thread, and **summarise** to the requester (see Reply-back convention).
+
+## Title hygiene (all types)
+
+Every work item title must be **safe to share with a client** and professional, regardless of how it's created (including ad-hoc via `az boards`):
+- Rephrase internal slang/shorthand — "Chase X" → "Follow up X".
+- Prefer a **role or company** over an individual's personal name where possible.
+- Avoid HR/immigration/visa specifics, and commercially sensitive detail (rates, margins).
+- Keep it concise and outcome-oriented.
+
+If you change the wording from what was said, note it in the reply-back (so the requester can see "Chase HRB" was logged as "Follow up HRB").
+
+## Writing the description
+
+A work item is only useful if its description carries the context — **don't leave it blank or log just a title.**
+
+- **Aim for enough detail that someone picking it up cold understands it** — the background, what "done" looks like, and any links (related work items, documents, the PR/repo).
+- **Meeting-created items:** if it came out of a meeting or stand-up, **look at the transcript / chat / notes** to enrich the description — who asked for it, why, and any decisions or acceptance detail discussed. For a long transcript, **delegate a sub-agent via `Task`** to read it and draft the description, then review before logging.
+- **Match the type's fields** (see Per-type specifics) — a Bug needs repro steps; a Risk needs impact + mitigation; etc.
+- Keep it client-safe (same rules as titles).
+
+## Reply-back convention (important)
+
+After logging, do **two** reply-backs:
+
+**1. In the meeting thread / chat** — quote the person's original comment and reply with the linked item, so the action and its tracker entry sit together:
+
+> [Task 1234](https://dev.azure.com/<your-org>/<project>/_workitems/edit/1234): Create partnership document (`<project>`)
+
+Format: **`[<Type> <ID>](url): <Title> (<project>[ — assigned to <name>])`**, where `<Type> <ID>` is the hyperlink. Append the assignee when it's someone other than the requester.
+
+**2. Summarise back to the requester** — one line per item, then a roll-up table:
+
+> - **#1234 — Create partnership document** (Task, `<project>`, assigned to <name>, State: New) — [open](https://.../edit/1234)
+
+Roll-up + cross-reference table (so each thing raised maps to what was logged):
+
+> | Raised | Logged as | Link |
+> |---|---|---|
+> | Create partnership doc | Task **1234** | [edit/1234](https://.../edit/1234) |
+> | Chase supplier for quote | Task **1235** (titled "Follow up supplier quote") | [edit/1235](https://.../edit/1235) |
+
+Use ✅ to confirm an *action completed* ("Logged and posted ✅"), not as a per-item prefix.

--- a/agent/spine.py
+++ b/agent/spine.py
@@ -1,0 +1,199 @@
+"""
+Preppie spine - transcript -> Azure AI Foundry agent (Responses API) -> triaged Azure DevOps
+backlog, with dedupe.
+
+This is the meeting-to-backlog core (#27 + #62): the agent reasons over the transcript and drives
+the deployed backend tools. Tool-calling is a thin, stateless loop - no separate long-running
+middleware. Both the LLM client and the backend are injected, so the loop is unit-testable without
+network access (see tests/test_spine.py).
+"""
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+import urllib.error
+from typing import Any, Callable
+
+
+# ---------- transcript parsing ----------
+def parse_vtt(text: str) -> str:
+    """Flatten a WEBVTT transcript to 'Speaker: text' lines (drops cue numbers/timestamps)."""
+    lines = []
+    for raw in text.splitlines():
+        s = raw.strip()
+        if not s or s == "WEBVTT" or "-->" in s or s.isdigit():
+            continue
+        head, sep, tail = s.replace("<v ", "").partition(">")
+        if sep:  # had a <v Name> voice tag
+            lines.append(f"{head.strip()}: {tail.strip()}")
+        else:
+            lines.append(s)
+    return "\n".join(lines)
+
+
+def read_transcript(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    return parse_vtt(text) if path.lower().endswith(".vtt") else text
+
+
+# ---------- backend tool dispatch ----------
+class Backend:
+    """Calls the deployed Azure Functions backend. Every call is scoped to one project."""
+
+    def __init__(self, base_url: str, project: str, opener: Callable | None = None,
+                 attempts: int = 4):
+        self.base_url = base_url.rstrip("/")
+        self.project = project
+        self._opener = opener or urllib.request.urlopen
+        self._attempts = attempts
+
+    def _request(self, path: str, method: str, body: dict | None) -> dict:
+        # Retry transient connection blips and 5xx (Flex Consumption cold-scale can drop a
+        # connection); a single hiccup must not abort a whole meeting's backlog.
+        data = json.dumps(body).encode() if body is not None else None
+        for attempt in range(self._attempts):
+            req = urllib.request.Request(
+                f"{self.base_url}{path}", data=data, method=method,
+                headers={"Content-Type": "application/json"})
+            try:
+                with self._opener(req, timeout=45) as r:
+                    return json.loads(r.read().decode())
+            except urllib.error.HTTPError as e:
+                if e.code >= 500 and attempt < self._attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                return {"success": False, "error": f"HTTP {e.code}: {e.read().decode()[:300]}"}
+            except urllib.error.URLError as e:
+                if attempt < self._attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                return {"success": False, "error": f"connection error after {self._attempts} tries: {e}"}
+        return {"success": False, "error": "no request attempts made (attempts must be >= 1)"}
+
+    def dispatch(self, name: str, args: dict) -> dict:
+        """Route a tool call to the backend, injecting the project. Returns the backend JSON."""
+        if name == "read_projects":
+            return self._request("/api/read_projects", "GET", None)
+        if name == "search_work_items":
+            return self._request("/api/search_work_items", "POST", {**args, "project": self.project})
+        if name == "create_work_item":
+            return self._request("/api/create_work_item", "POST", {**args, "project": self.project})
+        if name == "link_work_items":
+            return self._request("/api/link_work_items", "POST", {**args, "project": self.project})
+        return {"success": False, "error": f"unknown tool {name}"}
+
+
+# ---------- tool schemas (match the deployed backend contract) ----------
+TOOLS: list[dict[str, Any]] = [
+    {"type": "function", "name": "read_projects",
+     "description": "List Azure DevOps projects in the org. Use to confirm the target project exists.",
+     "parameters": {"type": "object", "properties": {}, "required": []}},
+    {"type": "function", "name": "search_work_items",
+     "description": "Search existing work items in the target project. Use for DEDUPE before creating "
+                    "(titleContains), and to find a just-created parent.",
+     "parameters": {"type": "object", "properties": {
+         "titleContains": {"type": "string", "description": "Substring to match in the title."},
+         "workItemType": {"type": "string", "description": "Filter by type e.g. Task, Bug, Issue, Epic, Feature, User Story."},
+         "state": {"type": "string"},
+         "tags": {"type": "string", "description": "Substring to match in the item's tags (e.g. 'Risk')."},
+         "top": {"type": "integer"}}, "required": []}},
+    {"type": "function", "name": "create_work_item",
+     "description": "Create one work item in the target project. Returns its id and url. "
+                    "Apply the type->ADO mapping and tags from your instructions.",
+     "parameters": {"type": "object", "properties": {
+         "type": {"type": "string", "description": "Azure DevOps type: Task, Bug, Issue, Epic, Feature, or User Story."},
+         "title": {"type": "string", "description": "Clean, client-safe title (no type prefix)."},
+         "description": {"type": "string", "description": "Rich description: context, who raised it, definition of done."},
+         "acceptanceCriteria": {"type": "array", "items": {"type": "string"},
+                                 "description": "User Stories only. AMP form (Acceptance/Measure/Proof)."},
+         "tags": {"type": "array", "items": {"type": "string"},
+                  "description": "Triage tag when the native type differs, e.g. ['Enhancement'], ['Risk'], ['Question']."},
+         "priority": {"type": "integer", "description": "1 (highest) to 4."},
+         "estimatedEffort": {"type": "string", "description": "Optional effort/size estimate, e.g. '3', '5', '8'."}},
+         "required": ["type", "title", "description"]}},
+    {"type": "function", "name": "link_work_items",
+     "description": "Link a parent to child work items (parent-child hierarchy). "
+                    "sourceId = parent id, targetIds = child ids.",
+     "parameters": {"type": "object", "properties": {
+         "sourceId": {"type": "integer", "description": "Parent work item id."},
+         "targetIds": {"type": "array", "items": {"type": "integer"}, "description": "Child work item ids."},
+         "linkType": {"type": "string", "description": "Default System.LinkTypes.Hierarchy-Forward (parent->child)."}},
+         "required": ["sourceId", "targetIds"]}},
+]
+
+USER_PROMPT = (
+    "Process this meeting transcript into the backlog now. Dedupe before creating, build the "
+    "Epic/Feature/User Story structure, attach captured items under the nearest relevant parent, "
+    "and finish with the reply-back roll-up table.\n\n=== TRANSCRIPT ===\n"
+)
+
+
+def run_spine(transcript: str, instructions: str, client, backend: Backend, model: str,
+              *, on_event: Callable[[str], None] | None = None, max_turns: int = 30) -> dict:
+    """
+    Drive the Responses-API tool loop until the model stops calling tools.
+
+    `client` must expose `responses.create(...)` (an openai AzureOpenAI, or a fake in tests).
+    Returns {created: [...backend results...], reply_back: str, turns: int}.
+    """
+    def emit(msg: str) -> None:
+        if on_event:
+            on_event(msg)
+
+    resp = client.responses.create(
+        model=model, instructions=instructions,
+        input=[{"role": "user", "content": USER_PROMPT + transcript}], tools=TOOLS)
+
+    created: list[dict] = []
+    truncated = False
+    turns = 0
+    for turns in range(1, max_turns + 1):
+        calls = [o for o in resp.output if getattr(o, "type", None) == "function_call"]
+        if not calls:
+            break
+        outputs = []
+        for c in calls:
+            try:
+                args = json.loads(c.arguments or "{}")
+                if not isinstance(args, dict):
+                    raise ValueError(f"expected a JSON object, got {type(args).__name__}")
+            except (json.JSONDecodeError, ValueError) as e:
+                # A malformed tool call must not kill the whole run (and every call_id still
+                # needs a matching output, or the next Responses API call is invalid) - report
+                # it back to the model as a failed call and move on.
+                result = {"success": False, "error": f"malformed arguments for {c.name}: {e}"}
+                emit(f"BAD ARGS for {c.name}: {c.arguments!r} ({e})")
+                outputs.append({"type": "function_call_output", "call_id": c.call_id,
+                                 "output": json.dumps(result)})
+                continue
+            result = backend.dispatch(c.name, args)
+            if c.name == "create_work_item" and result.get("success"):
+                created.append(result)
+                emit(f"create {result['work_item_type']} #{result['work_item_id']}: {result['title']}")
+            elif c.name == "create_work_item":
+                emit(f"CREATE FAILED: {result.get('error')}")
+            elif c.name == "search_work_items":
+                emit(f"dedupe '{args.get('titleContains', '')}' -> {result.get('count', '?')} match(es)")
+            elif c.name == "link_work_items":
+                emit(f"link parent {args.get('sourceId')} -> {args.get('targetIds')}")
+            outputs.append({"type": "function_call_output", "call_id": c.call_id, "output": json.dumps(result)})
+        resp = client.responses.create(
+            model=model, instructions=instructions,
+            previous_response_id=resp.id, input=outputs, tools=TOOLS)
+    else:
+        # The for-loop ran out of turns without ever hitting the `break` above, i.e. the model
+        # was still calling tools when the budget ran out. The last resp we just got back may
+        # itself carry unserviced function_calls and therefore no real reply_back text - don't
+        # let that surface as a silent blank summary when items may already have been created.
+        pending = [o for o in resp.output if getattr(o, "type", None) == "function_call"]
+        if pending:
+            truncated = True
+            emit(f"max_turns ({max_turns}) reached with {len(pending)} pending tool call(s); stopping")
+
+    reply_back = resp.output_text
+    if truncated and not reply_back:
+        reply_back = (f"[Preppie stopped after {max_turns} turns without a final reply - "
+                       f"{len(created)} item(s) were created; check Azure DevOps directly.]")
+    return {"created": created, "reply_back": reply_back, "turns": turns}

--- a/agent/tests/fixtures/sample-meeting.vtt
+++ b/agent/tests/fixtures/sample-meeting.vtt
@@ -1,0 +1,40 @@
+WEBVTT
+
+00:00:01.000 --> 00:00:08.200
+<v Priya Sharma>Okay, thanks for jumping on. The main thing I want to lock down today is the customer self-service portal for Q3. It's a big one — I'd call it our flagship initiative for the quarter.
+
+00:00:08.500 --> 00:00:15.000
+<v Daniel Okoro>Agreed. So at a high level the portal is the umbrella, and under it we've got at least the account management piece and the billing view. Those feel like two separate features to me.
+
+00:00:15.400 --> 00:00:24.800
+<v Priya Sharma>Right. For account management, the concrete thing customers keep asking for is: as a signed-in user I want to update my own contact details without raising a support ticket. That's a clear user story.
+
+00:00:25.100 --> 00:00:31.600
+<v Daniel Okoro>Makes sense. Given a logged-in user, when they change their email, then we send a confirmation link before it takes effect — otherwise we'll get account takeover complaints.
+
+00:00:32.000 --> 00:00:40.300
+<v Priya Sharma>Good, add that as the acceptance criteria. Now, separate thing — we already have a bug in the current portal. The session times out after about two minutes and dumps people back to login. It's been reported by three enterprise customers.
+
+00:00:40.700 --> 00:00:47.100
+<v Daniel Okoro>Yeah I've seen that one. It's the token refresh not firing. That's definitely a bug, not new work — we should log it and prioritise it high.
+
+00:00:47.500 --> 00:00:56.900
+<v Priya Sharma>One risk I want on the record: the billing view depends on the third-party invoicing API, and their rate limits are pretty aggressive. If we design the dashboard to call it live per page load, we could get throttled in production.
+
+00:00:57.300 --> 00:01:04.200
+<v Daniel Okoro>That's a real risk. We might need a caching layer. Actually — would it be worth caching invoices for, say, fifteen minutes? That'd cut the calls dramatically.
+
+00:01:04.600 --> 00:01:12.500
+<v Priya Sharma>That's a nice enhancement on top of the billing feature — let's capture it as an improvement rather than baking it into the core story for now.
+
+00:01:12.900 --> 00:01:21.400
+<v Daniel Okoro>One thing I'm genuinely unsure about: when we say "customers can manage their account", does that include deleting the account entirely? Because GDPR erasure is a whole separate workflow with legal sign-off.
+
+00:01:21.800 --> 00:01:29.000
+<v Priya Sharma>Good question — I don't have the answer. Let's flag that as an open question for legal before we scope the deletion flow. Don't guess at it.
+
+00:01:29.400 --> 00:01:36.700
+<v Daniel Okoro>Perfect. And a small task on my side — I'll set up the feature branch and the CI pipeline for the portal repo so we're ready to build. Nothing fancy, just the plumbing.
+
+00:01:37.000 --> 00:01:42.300
+<v Priya Sharma>Great. I think that's a solid backlog. Let's get it written up properly and we'll review it at standup tomorrow.

--- a/agent/tests/test_spine.py
+++ b/agent/tests/test_spine.py
@@ -1,0 +1,236 @@
+"""Unit tests for the Preppie spine. No network: the backend and the LLM client are injected."""
+import json
+import os
+import types
+
+from agent.spine import parse_vtt, read_transcript, Backend, run_spine
+
+
+# ---------- transcript parsing ----------
+def test_parse_vtt_extracts_speakers():
+    vtt = ("WEBVTT\n\n1\n00:00:01.000 --> 00:00:03.000\n<v Alice>Hello there\n\n"
+           "00:00:04.000 --> 00:00:05.000\n<v Bob>Hi Alice\n")
+    assert parse_vtt(vtt) == "Alice: Hello there\nBob: Hi Alice"
+
+
+def test_parse_vtt_keeps_untagged_lines_and_drops_noise():
+    assert parse_vtt("WEBVTT\n\n2\n00:00:01.000 --> 00:00:02.000\nplain line\n") == "plain line"
+
+
+def test_read_transcript_plain_file_is_verbatim(tmp_path):
+    p = tmp_path / "notes.txt"
+    p.write_text("Alice: just do it")
+    assert read_transcript(str(p)) == "Alice: just do it"
+
+
+def test_sample_fixture_parses():
+    fixture = os.path.join(os.path.dirname(__file__), "fixtures", "sample-meeting.vtt")
+    out = read_transcript(fixture)
+    assert "Priya Sharma:" in out and "Daniel Okoro:" in out and "-->" not in out
+
+
+# ---------- backend dispatch ----------
+class _FakeResp:
+    def __init__(self, body):
+        self._b = json.dumps(body).encode()
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_backend_dispatch_injects_project_and_posts():
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["body"] = json.loads(req.data.decode()) if req.data else None
+        return _FakeResp({"success": True, "count": 0})
+
+    Backend("https://backend.example/", "MyProj", opener=opener).dispatch(
+        "search_work_items", {"titleContains": "foo"})
+    assert seen["url"].endswith("/api/search_work_items")
+    assert seen["method"] == "POST"
+    assert seen["body"] == {"project": "MyProj", "titleContains": "foo"}
+
+
+def test_backend_read_projects_is_get_no_body():
+    def opener(req, timeout=None):
+        assert req.get_method() == "GET"
+        assert req.data is None
+        return _FakeResp({"success": True, "projects": []})
+
+    Backend("https://b", "P", opener=opener).dispatch("read_projects", {})
+
+
+def test_backend_retries_transient_connection_error(monkeypatch):
+    import urllib.error
+    monkeypatch.setattr("agent.spine.time.sleep", lambda *_: None)  # no real backoff in tests
+    calls = {"n": 0}
+
+    def flaky_opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise urllib.error.URLError("connection refused")
+        return _FakeResp({"success": True, "count": 0})
+
+    out = Backend("https://b", "P", opener=flaky_opener).dispatch("search_work_items", {})
+    assert out["success"] is True and calls["n"] == 3  # failed twice, succeeded on the third
+
+
+def test_backend_gives_up_after_attempts(monkeypatch):
+    import urllib.error
+    monkeypatch.setattr("agent.spine.time.sleep", lambda *_: None)
+
+    def always_refuse(req, timeout=None):
+        raise urllib.error.URLError("refused")
+
+    out = Backend("https://b", "P", opener=always_refuse, attempts=3).dispatch("read_projects", {})
+    assert out["success"] is False and "connection error" in out["error"]
+
+
+def test_backend_dispatch_project_cannot_be_overridden_by_args():
+    # The backend's guarantee is that every call is scoped to Backend.project. If the model's
+    # tool-call arguments ever contained a stray "project" key, it must not win over that.
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["body"] = json.loads(req.data.decode())
+        return _FakeResp({"success": True})
+
+    Backend("https://b", "RealProject", opener=opener).dispatch(
+        "create_work_item", {"type": "Task", "title": "t", "description": "d", "project": "Hijacked"})
+    assert seen["body"]["project"] == "RealProject"
+
+
+# ---------- the run loop ----------
+def _fcall(name, args, call_id):
+    return types.SimpleNamespace(type="function_call", name=name,
+                                 arguments=json.dumps(args), call_id=call_id)
+
+
+class _FakeClient:
+    """Replays a scripted list of (output_items, output_text) responses."""
+
+    def __init__(self, scripted):
+        self._scripted = list(scripted)
+        self._n = 0
+        self.calls = []
+        self.responses = self
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        out, text = self._scripted[self._n]
+        self._n += 1
+        return types.SimpleNamespace(output=out, output_text=text, id=f"resp_{self._n}")
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.dispatched = []
+        self._next_id = 100
+
+    def dispatch(self, name, args):
+        self.dispatched.append((name, args))
+        if name == "create_work_item":
+            self._next_id += 1
+            return {"success": True, "work_item_id": self._next_id,
+                    "work_item_type": args["type"], "title": args["title"], "url": "http://x"}
+        if name == "search_work_items":
+            return {"success": True, "count": 0, "workItems": []}
+        return {"success": True}
+
+
+def test_run_spine_dedupes_before_create_and_collects_results():
+    scripted = [
+        ([_fcall("search_work_items", {"titleContains": "Portal"}, "c1"),
+          _fcall("create_work_item", {"type": "Epic", "title": "Portal", "description": "d"}, "c2")], ""),
+        ([], "done: logged 1 item"),
+    ]
+    client, backend = _FakeClient(scripted), _FakeBackend()
+    result = run_spine("Alice: build a portal", "INSTR", client, backend, "gpt-x")
+
+    names = [n for n, _ in backend.dispatched]
+    assert names.index("search_work_items") < names.index("create_work_item")  # dedupe first
+    assert len(result["created"]) == 1
+    assert result["created"][0]["title"] == "Portal"
+    assert result["reply_back"] == "done: logged 1 item"
+    # tool outputs were fed back referencing the prior response id
+    assert client.calls[1].get("previous_response_id") == "resp_1"
+
+
+def test_run_spine_terminates_at_max_turns():
+    forever = ([_fcall("search_work_items", {}, "c")], "")
+    result = run_spine("t", "i", _FakeClient([forever] * 50), _FakeBackend(), "m", max_turns=5)
+    assert result["turns"] == 5
+    # the model never produced a final text reply (it kept calling tools) - the caller must still
+    # get a non-blank explanation rather than silently seeing an empty reply-back.
+    assert result["reply_back"] and "5 turns" in result["reply_back"]
+
+
+def test_run_spine_handles_malformed_tool_arguments_without_crashing():
+    scripted = [
+        ([types.SimpleNamespace(type="function_call", name="create_work_item",
+                                arguments="{not valid json", call_id="c1")], ""),
+        ([], "done"),
+    ]
+    client, backend = _FakeClient(scripted), _FakeBackend()
+    result = run_spine("t", "i", client, backend, "m")
+    # the bad call must never reach the backend, but the loop must still feed an output back
+    # (referencing the same call_id) so the model isn't left hanging, and the run completes.
+    assert backend.dispatched == []
+    assert result["reply_back"] == "done"
+    second_call_outputs = client.calls[1]["input"]
+    assert second_call_outputs[0]["call_id"] == "c1"
+    assert json.loads(second_call_outputs[0]["output"])["success"] is False
+
+
+def test_run_spine_handles_non_object_tool_arguments():
+    scripted = [
+        ([types.SimpleNamespace(type="function_call", name="search_work_items",
+                                arguments="[1, 2, 3]", call_id="c1")], ""),
+        ([], "done"),
+    ]
+    result = run_spine("t", "i", _FakeClient(scripted), _FakeBackend(), "m")
+    assert result["reply_back"] == "done"
+
+
+class _FailingCreateBackend:
+    """A backend whose create_work_item always fails, to check the loop doesn't leave the model
+    hanging (every call_id still needs a function_call_output) or lose track of the run."""
+
+    def __init__(self):
+        self.dispatched = []
+
+    def dispatch(self, name, args):
+        self.dispatched.append((name, args))
+        return {"success": False, "error": "Azure DevOps rejected the request"}
+
+
+def test_run_spine_feeds_output_back_after_failed_create():
+    scripted = [
+        ([_fcall("create_work_item", {"type": "Task", "title": "T", "description": "d"}, "c1")], ""),
+        ([], "done: 0 items logged"),
+    ]
+    client = _FakeClient(scripted)
+    result = run_spine("t", "i", client, _FailingCreateBackend(), "m")
+
+    assert result["created"] == []  # nothing to show for a failed create
+    assert result["reply_back"] == "done: 0 items logged"  # the loop still completed normally
+    fed_back = client.calls[1]["input"]
+    assert fed_back[0]["call_id"] == "c1"
+    assert json.loads(fed_back[0]["output"])["success"] is False
+
+
+def test_run_spine_records_events():
+    events = []
+    scripted = [([_fcall("create_work_item", {"type": "Task", "title": "T", "description": "d"}, "c1")], ""),
+                ([], "ok")]
+    run_spine("t", "i", _FakeClient(scripted), _FakeBackend(), "m", on_event=events.append)
+    assert any("create Task" in e for e in events)

--- a/agent/tests/test_transcript_fetch.py
+++ b/agent/tests/test_transcript_fetch.py
@@ -1,0 +1,722 @@
+"""Unit tests for agent.transcript_fetch. No network: the HTTP opener is injected everywhere,
+and agent.transcript_fetch.time.sleep is monkeypatched so polling/backoff tests run instantly."""
+import email.utils
+import io
+import json
+import time
+import urllib.error
+import urllib.parse
+
+import pytest
+
+from agent.transcript_fetch import (
+    GraphClient,
+    GraphError,
+    download_transcript_vtt,
+    fetch_meeting_vtt,
+    find_meeting_id,
+    get_app_token,
+    list_transcripts,
+)
+
+
+# =========================================================================
+# shared fakes (mirror agent.tests.test_spine._FakeResp / test_reply_back._FakeResp)
+# =========================================================================
+class _FakeResp:
+    def __init__(self, body=b"", status=200, headers=None):
+        self._b = body if isinstance(body, bytes) else json.dumps(body).encode()
+        self.status = status
+        self.code = status
+        self.headers = headers or {}
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _http_error(code, body=b"", headers=None):
+    if not isinstance(body, bytes):
+        body = json.dumps(body).encode()
+    return urllib.error.HTTPError(
+        url="https://graph.microsoft.com/v1.0/x", code=code, msg=f"HTTP {code}",
+        hdrs=headers or {}, fp=None if body == b"" else io.BytesIO(body))
+
+
+class _ScriptedOpener:
+    """Routes requests to canned responses by URL substring, tried in the given order. Each
+    route's response list is popped left-to-right, repeating its last entry once exhausted -
+    so a route can script "fail twice then succeed" or just "always return this"."""
+
+    def __init__(self, routes):
+        self.routes = [(substr, list(resps)) for substr, resps in routes]
+        self.calls = []
+
+    def __call__(self, req, timeout=None):
+        url = req.full_url
+        self.calls.append(req)
+        for substr, queue in self.routes:
+            if substr in url:
+                item = queue.pop(0) if len(queue) > 1 else queue[0]
+                if isinstance(item, BaseException):
+                    raise item
+                return item
+        raise AssertionError(f"unrouted request: {url}")
+
+
+TOKEN_ROUTE = "login.microsoftonline.com"
+
+
+def _token_resp(token="tok-123"):
+    return _FakeResp({"access_token": token, "token_type": "Bearer", "expires_in": 3600})
+
+
+# =========================================================================
+# get_app_token
+# =========================================================================
+def test_get_app_token_success_posts_client_credentials_form():
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["content_type"] = req.get_header("Content-type")
+        seen["body"] = urllib.parse.parse_qs(req.data.decode())
+        return _token_resp("abc123")
+
+    token = get_app_token("ten1", "client1", "secret1", opener=opener)
+
+    assert token == "abc123"
+    assert seen["url"] == "https://login.microsoftonline.com/ten1/oauth2/v2.0/token"
+    assert seen["method"] == "POST"
+    assert seen["content_type"] == "application/x-www-form-urlencoded"
+    assert seen["body"] == {
+        "grant_type": ["client_credentials"],
+        "client_id": ["client1"],
+        "client_secret": ["secret1"],
+        "scope": ["https://graph.microsoft.com/.default"],
+    }
+
+
+def test_get_app_token_custom_scope_is_sent():
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["body"] = urllib.parse.parse_qs(req.data.decode())
+        return _token_resp()
+
+    get_app_token("t", "c", "s", opener=opener, scope="custom/.default")
+    assert seen["body"]["scope"] == ["custom/.default"]
+
+
+def test_get_app_token_http_error_surfaces_error_description():
+    def opener(req, timeout=None):
+        raise _http_error(401, body={"error": "invalid_client",
+                                      "error_description": "AADSTS7000215: Invalid client secret"})
+
+    with pytest.raises(GraphError) as exc:
+        get_app_token("t", "c", "wrong-secret", opener=opener)
+    assert "AADSTS7000215" in str(exc.value)
+
+
+def test_get_app_token_http_error_without_json_body_still_raises_clean_error():
+    def opener(req, timeout=None):
+        raise _http_error(400, body=b"not json")
+
+    with pytest.raises(GraphError) as exc:
+        get_app_token("t", "c", "s", opener=opener)
+    assert "HTTP 400" in str(exc.value)
+
+
+def test_get_app_token_urlerror_raises_graph_error(monkeypatch):
+    # get_app_token now retries URLError like GraphClient.get does (finding #3) - patch sleep so
+    # this exhausts its retries instantly instead of waiting on real backoff.
+    monkeypatch.setattr("agent.transcript_fetch.time.sleep", lambda *_: None)
+
+    def opener(req, timeout=None):
+        raise urllib.error.URLError("connection refused")
+
+    with pytest.raises(GraphError) as exc:
+        get_app_token("t", "c", "s", opener=opener)
+    assert "connection error" in str(exc.value)
+
+
+def test_get_app_token_missing_access_token_raises_graph_error():
+    def opener(req, timeout=None):
+        return _FakeResp({"error": "unauthorized_client", "error_description": "app not authorized"})
+
+    with pytest.raises(GraphError) as exc:
+        get_app_token("t", "c", "s", opener=opener)
+    assert "app not authorized" in str(exc.value)
+
+
+def test_get_app_token_retries_5xx_then_succeeds(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.transcript_fetch.time.sleep", lambda s: sleeps.append(s))
+    calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _http_error(503)
+        return _token_resp("retried-token")
+
+    token = get_app_token("t", "c", "s", opener=opener, attempts=4)
+
+    assert token == "retried-token"
+    assert calls["n"] == 3
+    assert len(sleeps) == 2
+
+
+# =========================================================================
+# GraphClient.get
+# =========================================================================
+def test_graphclient_get_success_returns_status_and_body_and_sets_auth_header():
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["auth"] = req.get_header("Authorization")
+        seen["accept"] = req.get_header("Accept")
+        return _FakeResp({"value": []}, status=200)
+
+    status, body = GraphClient("mytoken", opener=opener).get("/users/u1/onlineMeetings")
+
+    assert status == 200
+    assert json.loads(body.decode()) == {"value": []}
+    assert seen["url"] == "https://graph.microsoft.com/v1.0/users/u1/onlineMeetings"
+    assert seen["auth"] == "Bearer mytoken"
+    assert seen["accept"] == "application/json"
+
+
+def test_graphclient_get_absolute_url_used_as_is():
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        return _FakeResp({"ok": True})
+
+    GraphClient("t", opener=opener).get("https://graph.microsoft.com/v1.0/other/path")
+    assert seen["url"] == "https://graph.microsoft.com/v1.0/other/path"
+
+
+def test_graphclient_get_custom_accept_header():
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["accept"] = req.get_header("Accept")
+        return _FakeResp(b"WEBVTT\n")
+
+    GraphClient("t", opener=opener).get("/x", accept="text/vtt")
+    assert seen["accept"] == "text/vtt"
+
+
+def test_graphclient_get_retries_5xx_then_succeeds(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.transcript_fetch.time.sleep", lambda s: sleeps.append(s))
+    calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _http_error(503)
+        return _FakeResp({"ok": True}, status=200)
+
+    status, body = GraphClient("t", opener=opener, attempts=4).get("/x")
+    assert status == 200 and calls["n"] == 3 and len(sleeps) == 2
+
+
+def test_graphclient_get_retries_urlerror_then_gives_up():
+    def always_refuse(req, timeout=None):
+        raise urllib.error.URLError("refused")
+
+    with pytest.raises(GraphError) as exc:
+        GraphClient("t", opener=always_refuse, attempts=3).get("/x")
+    assert "connection error after 3 tries" in str(exc.value)
+
+
+def test_graphclient_get_429_retry_after_honored_capped_at_30(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.transcript_fetch.time.sleep", lambda s: sleeps.append(s))
+    calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _http_error(429, headers={"Retry-After": "120"})
+        return _FakeResp({"ok": True})
+
+    status, _ = GraphClient("t", opener=opener, attempts=3).get("/x")
+    assert status == 200
+    assert sleeps == [30.0]
+
+
+def test_graphclient_get_429_retry_after_below_cap_honored_exactly(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.transcript_fetch.time.sleep", lambda s: sleeps.append(s))
+    calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _http_error(429, headers={"Retry-After": "5"})
+        return _FakeResp({"ok": True})
+
+    GraphClient("t", opener=opener, attempts=3).get("/x")
+    assert sleeps == [5.0]
+
+
+def test_graphclient_get_429_retry_after_http_date_is_honored(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.transcript_fetch.time.sleep", lambda s: sleeps.append(s))
+    calls = {"n": 0}
+    # ~10s in the future, formatted as an HTTP-date (RFC 1123) - the format Retry-After may use
+    # instead of a plain integer-seconds value.
+    future_date = email.utils.formatdate(time.time() + 10, usegmt=True)
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _http_error(429, headers={"Retry-After": future_date})
+        return _FakeResp({"ok": True})
+
+    status, _ = GraphClient("t", opener=opener, attempts=3).get("/x")
+
+    assert status == 200
+    assert len(sleeps) == 1
+    # Loosely pinned to avoid clock flakiness: well above the plain 1.5s default backoff, and
+    # under the 30s cap.
+    assert 5 < sleeps[0] <= 30.0
+
+
+def test_graphclient_get_429_retry_after_unparseable_falls_back_to_default_backoff(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.transcript_fetch.time.sleep", lambda s: sleeps.append(s))
+    calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _http_error(429, headers={"Retry-After": "not-a-number-or-date"})
+        return _FakeResp({"ok": True})
+
+    GraphClient("t", opener=opener, attempts=3).get("/x")
+    assert sleeps == [1.5]  # attempt 0 default backoff: 1.5 * (0 + 1)
+
+
+def test_graphclient_get_non_2xx_with_graph_error_body_surfaces_message():
+    def opener(req, timeout=None):
+        raise _http_error(403, body={"error": {"code": "Forbidden",
+                                                "message": "app lacks OnlineMeetings.Read.All"}})
+
+    with pytest.raises(GraphError) as exc:
+        GraphClient("t", opener=opener, attempts=2).get("/x")
+    assert "Forbidden" in str(exc.value) and "OnlineMeetings.Read.All" in str(exc.value)
+
+
+def test_graphclient_get_direct_non_2xx_response_object_is_handled_without_exception(monkeypatch):
+    # Some (test/custom) openers hand back a non-2xx response object directly instead of raising
+    # HTTPError - must be treated the same way, including retrying a direct 500 and a direct 429.
+    monkeypatch.setattr("agent.transcript_fetch.time.sleep", lambda *_: None)
+
+    def opener(req, timeout=None):
+        return _FakeResp({"error": {"code": "X", "message": "boom"}}, status=500)
+
+    with pytest.raises(GraphError) as exc:
+        GraphClient("t", opener=opener, attempts=2).get("/x")
+    assert "X" in str(exc.value) and "boom" in str(exc.value)
+
+
+def test_graphclient_get_gives_up_after_attempts_exhausted_on_5xx(monkeypatch):
+    monkeypatch.setattr("agent.transcript_fetch.time.sleep", lambda *_: None)
+
+    def always_503(req, timeout=None):
+        raise _http_error(503, body=b"upstream down")
+
+    with pytest.raises(GraphError) as exc:
+        GraphClient("t", opener=always_503, attempts=3).get("/x")
+    assert "503" in str(exc.value)
+
+
+# =========================================================================
+# find_meeting_id
+# =========================================================================
+def test_find_meeting_id_success_returns_first_meeting_id():
+    def opener(req, timeout=None):
+        return _FakeResp({"value": [{"id": "meeting-1"}, {"id": "meeting-2"}]})
+
+    client = GraphClient("t", opener=opener)
+    assert find_meeting_id(client, "organizer1", "https://teams.microsoft.com/l/x") == "meeting-1"
+
+
+def test_find_meeting_id_not_found_raises_graph_error():
+    def opener(req, timeout=None):
+        return _FakeResp({"value": []})
+
+    client = GraphClient("t", opener=opener)
+    with pytest.raises(GraphError) as exc:
+        find_meeting_id(client, "organizer1", "https://teams.microsoft.com/l/missing")
+    assert "meeting not found" in str(exc.value)
+    assert "access policy" in str(exc.value)
+
+
+def test_find_meeting_id_non_object_top_level_json_raises_graph_error_not_attributeerror():
+    def opener(req, timeout=None):
+        return _FakeResp(b"[]")  # a bare JSON array, not an object with .get()
+
+    client = GraphClient("t", opener=opener)
+    with pytest.raises(GraphError) as exc:
+        find_meeting_id(client, "organizer1", "https://teams.microsoft.com/l/x")
+    assert "list" in str(exc.value) or "onlineMeetings" in str(exc.value)
+
+
+def test_find_meeting_id_value_item_missing_id_raises_graph_error_not_keyerror():
+    def opener(req, timeout=None):
+        return _FakeResp({"value": [{"subject": "no id here"}]})
+
+    client = GraphClient("t", opener=opener)
+    with pytest.raises(GraphError) as exc:
+        find_meeting_id(client, "organizer1", "https://teams.microsoft.com/l/x")
+    assert "id" in str(exc.value)
+
+
+def test_find_meeting_id_uses_correct_path_and_url_encodes_organizer():
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        return _FakeResp({"value": [{"id": "m1"}]})
+
+    client = GraphClient("t", opener=opener)
+    find_meeting_id(client, "user@contoso.com", "https://teams.microsoft.com/l/x")
+    assert seen["url"].startswith(
+        "https://graph.microsoft.com/v1.0/users/user%40contoso.com/onlineMeetings?")
+
+
+def test_find_meeting_id_url_encodes_filter_with_special_chars():
+    # Note: this URL contains a literal apostrophe (in "a b's"), which OData V4 requires be
+    # escaped by doubling it ('' ) inside the filter's string literal - see
+    # test_find_meeting_id_escapes_odata_single_quote for that behavior specifically. Here we
+    # just check the round-trip of the (already-escaped) filter value through percent-encoding.
+    join_url = "https://teams.microsoft.com/l/meetup-join/19%3ameeting_abc?tenantId=t1&x=a b's \"q\""
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        return _FakeResp({"value": [{"id": "m1"}]})
+
+    client = GraphClient("t", opener=opener)
+    find_meeting_id(client, "organizer1", join_url)
+
+    parsed = urllib.parse.urlparse(seen["url"])
+    qs = urllib.parse.parse_qs(parsed.query)
+    expected_odata_value = join_url.replace("'", "''")
+    assert qs["$filter"] == [f"JoinWebUrl eq '{expected_odata_value}'"]
+
+
+def test_find_meeting_id_escapes_odata_single_quote():
+    """A join URL containing a literal apostrophe must have it doubled ('') in the OData
+    $filter value per OData V4 string-literal escaping - otherwise Graph returns 400."""
+    join_url = "https://teams.microsoft.com/l/meetup-join/19:meeting_o'brien@thread.v2/0"
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        return _FakeResp({"value": [{"id": "m1"}]})
+
+    client = GraphClient("t", opener=opener)
+    find_meeting_id(client, "organizer1", join_url)
+
+    parsed = urllib.parse.urlparse(seen["url"])
+    qs = urllib.parse.parse_qs(parsed.query)
+    assert qs["$filter"] == ["JoinWebUrl eq 'https://teams.microsoft.com/l/meetup-join/19:meeting_o''brien@thread.v2/0'"]
+
+
+# =========================================================================
+# list_transcripts
+# =========================================================================
+def test_list_transcripts_empty_is_valid():
+    def opener(req, timeout=None):
+        return _FakeResp({"value": []})
+
+    client = GraphClient("t", opener=opener)
+    assert list_transcripts(client, "org1", "meeting1") == []
+
+
+def test_list_transcripts_returns_value_list_and_correct_path():
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        return _FakeResp({"value": [{"id": "tr1", "createdDateTime": "2026-07-01T00:00:00Z"}]})
+
+    client = GraphClient("t", opener=opener)
+    out = list_transcripts(client, "org1", "meeting1")
+
+    assert out == [{"id": "tr1", "createdDateTime": "2026-07-01T00:00:00Z"}]
+    assert seen["url"] == "https://graph.microsoft.com/v1.0/users/org1/onlineMeetings/meeting1/transcripts"
+
+
+def test_list_transcripts_non_object_top_level_json_raises_graph_error_not_attributeerror():
+    def opener(req, timeout=None):
+        return _FakeResp(b"[]")
+
+    client = GraphClient("t", opener=opener)
+    with pytest.raises(GraphError):
+        list_transcripts(client, "org1", "meeting1")
+
+
+def test_list_transcripts_403_gets_actionable_access_policy_hint():
+    def opener(req, timeout=None):
+        raise _http_error(403, body={"error": {"code": "Forbidden", "message": "denied"}})
+
+    client = GraphClient("t", opener=opener)
+    with pytest.raises(GraphError) as exc:
+        list_transcripts(client, "org1", "meeting1")
+    assert "denied" in str(exc.value)
+    assert "access policy" in str(exc.value)
+    assert "OnlineMeetingTranscript.Read.All" in str(exc.value)
+
+
+def test_list_transcripts_non_403_error_has_no_access_policy_hint():
+    def opener(req, timeout=None):
+        raise _http_error(404, body={"error": {"code": "NotFound", "message": "gone"}})
+
+    client = GraphClient("t", opener=opener)
+    with pytest.raises(GraphError) as exc:
+        list_transcripts(client, "org1", "meeting1")
+    assert "access policy" not in str(exc.value)
+
+
+# =========================================================================
+# download_transcript_vtt
+# =========================================================================
+def test_download_transcript_vtt_returns_decoded_text_with_correct_request():
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["accept"] = req.get_header("Accept")
+        return _FakeResp(b"WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\n<v Alice>Hi\n")
+
+    client = GraphClient("t", opener=opener)
+    vtt = download_transcript_vtt(client, "org1", "meeting1", "tr1")
+
+    assert vtt.startswith("WEBVTT")
+    assert "<v Alice>Hi" in vtt
+    assert seen["url"] == (
+        "https://graph.microsoft.com/v1.0/users/org1/onlineMeetings/meeting1"
+        "/transcripts/tr1/content?$format=text/vtt")
+    assert seen["accept"] == "text/vtt"
+
+
+def test_download_transcript_vtt_403_gets_actionable_access_policy_hint():
+    def opener(req, timeout=None):
+        raise _http_error(403, body={"error": {"code": "Forbidden", "message": "denied"}})
+
+    client = GraphClient("t", opener=opener)
+    with pytest.raises(GraphError) as exc:
+        download_transcript_vtt(client, "org1", "meeting1", "tr1")
+    assert "denied" in str(exc.value)
+    assert "access policy" in str(exc.value)
+    assert "OnlineMeetingTranscript.Read.All" in str(exc.value)
+
+
+# =========================================================================
+# fetch_meeting_vtt (full orchestration)
+# =========================================================================
+def _happy_routes(vtt_text=b"WEBVTT\n\n1\n00:00:00.000 --> 00:00:01.000\n<v Bob>Hello\n",
+                   transcripts=None):
+    transcripts = transcripts if transcripts is not None else [
+        {"id": "tr1", "createdDateTime": "2026-07-01T10:00:00Z"}]
+    return [
+        (TOKEN_ROUTE, [_token_resp("tok")]),
+        ("/content?$format=text/vtt", [_FakeResp(vtt_text)]),
+        ("/transcripts", [_FakeResp({"value": transcripts})]),
+        ("onlineMeetings?", [_FakeResp({"value": [{"id": "meeting-1"}]})]),
+    ]
+
+
+def test_fetch_meeting_vtt_happy_path_threads_all_calls_through_one_opener():
+    opener = _ScriptedOpener(_happy_routes())
+    vtt = fetch_meeting_vtt("tenant1", "client1", "secret1", "organizer1",
+                            "https://teams.microsoft.com/l/x", opener=opener)
+    assert vtt.startswith("WEBVTT")
+    assert "<v Bob>Hello" in vtt
+    # every leg of the pipeline actually made a request
+    urls = [r.full_url for r in opener.calls]
+    assert any(TOKEN_ROUTE in u for u in urls)
+    assert any("onlineMeetings?" in u for u in urls)
+    assert any(u.endswith("/transcripts") for u in urls)
+    assert any("/content?$format=text/vtt" in u for u in urls)
+
+
+def test_fetch_meeting_vtt_picks_latest_transcript_by_created_date_time():
+    transcripts = [
+        {"id": "old", "createdDateTime": "2026-01-01T00:00:00Z"},
+        {"id": "newest", "createdDateTime": "2026-06-15T12:00:00Z"},
+        {"id": "middle", "createdDateTime": "2026-03-01T00:00:00Z"},
+    ]
+    seen_content_url = {}
+
+    routes = [
+        (TOKEN_ROUTE, [_token_resp("tok")]),
+        ("onlineMeetings?", [_FakeResp({"value": [{"id": "meeting-1"}]})]),
+        ("/transcripts", [_FakeResp({"value": transcripts})]),
+    ]
+    opener = _ScriptedOpener(routes)
+
+    def wrapped(req, timeout=None):
+        if "/content?" in req.full_url:
+            seen_content_url["url"] = req.full_url
+            return _FakeResp(b"WEBVTT\nlatest content\n")
+        return opener(req, timeout=timeout)
+
+    vtt = fetch_meeting_vtt("t", "c", "s", "org1", "https://teams.microsoft.com/l/x", opener=wrapped)
+    assert "/transcripts/newest/content" in seen_content_url["url"]
+    assert "latest content" in vtt
+
+
+def test_fetch_meeting_vtt_no_transcript_single_attempt_raises_immediately(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.transcript_fetch.time.sleep", lambda s: sleeps.append(s))
+    routes = [
+        (TOKEN_ROUTE, [_token_resp()]),
+        ("onlineMeetings?", [_FakeResp({"value": [{"id": "meeting-1"}]})]),
+        ("/transcripts", [_FakeResp({"value": []})]),
+    ]
+    opener = _ScriptedOpener(routes)
+
+    with pytest.raises(GraphError) as exc:
+        fetch_meeting_vtt("t", "c", "s", "org1", "https://teams.microsoft.com/l/x",
+                          opener=opener, poll_attempts=1)
+    assert "no transcript available" in str(exc.value)
+    assert sleeps == []  # single attempt: never slept
+
+
+def test_fetch_meeting_vtt_polls_then_succeeds(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.transcript_fetch.time.sleep", lambda s: sleeps.append(s))
+    list_calls = {"n": 0}
+
+    def transcripts_handler(req):
+        list_calls["n"] += 1
+        if list_calls["n"] < 3:
+            return _FakeResp({"value": []})
+        return _FakeResp({"value": [{"id": "tr1", "createdDateTime": "2026-07-01T00:00:00Z"}]})
+
+    routes = [
+        (TOKEN_ROUTE, [_token_resp()]),
+        ("onlineMeetings?", [_FakeResp({"value": [{"id": "meeting-1"}]})]),
+    ]
+    base = _ScriptedOpener(routes)
+
+    def opener(req, timeout=None):
+        if req.full_url.endswith("/transcripts"):
+            return transcripts_handler(req)
+        if "/content?" in req.full_url:
+            return _FakeResp(b"WEBVTT\ndone\n")
+        return base(req, timeout=timeout)
+
+    vtt = fetch_meeting_vtt("t", "c", "s", "org1", "https://teams.microsoft.com/l/x",
+                            opener=opener, poll_attempts=3, poll_seconds=15)
+    assert "done" in vtt
+    assert list_calls["n"] == 3
+    assert sleeps == [15, 15]  # slept between attempts 1->2 and 2->3, not after the final success
+
+
+def test_fetch_meeting_vtt_polls_then_gives_up(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.transcript_fetch.time.sleep", lambda s: sleeps.append(s))
+    list_calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        if req.full_url.endswith("/transcripts"):
+            list_calls["n"] += 1
+            return _FakeResp({"value": []})
+        if TOKEN_ROUTE in req.full_url:
+            return _token_resp()
+        if "onlineMeetings?" in req.full_url:
+            return _FakeResp({"value": [{"id": "meeting-1"}]})
+        raise AssertionError(f"unexpected request {req.full_url}")
+
+    with pytest.raises(GraphError) as exc:
+        fetch_meeting_vtt("t", "c", "s", "org1", "https://teams.microsoft.com/l/x",
+                          opener=opener, poll_attempts=3, poll_seconds=1)
+    assert "no transcript available" in str(exc.value)
+    assert list_calls["n"] == 3
+    assert sleeps == [1, 1]
+
+
+def test_fetch_meeting_vtt_token_error_propagates():
+    def opener(req, timeout=None):
+        if TOKEN_ROUTE in req.full_url:
+            raise _http_error(401, body={"error": "invalid_client",
+                                          "error_description": "bad secret"})
+        raise AssertionError("should not reach Graph without a token")
+
+    with pytest.raises(GraphError) as exc:
+        fetch_meeting_vtt("t", "c", "wrong", "org1", "https://teams.microsoft.com/l/x", opener=opener)
+    assert "bad secret" in str(exc.value)
+
+
+def test_fetch_meeting_vtt_latest_transcript_missing_id_raises_graph_error_not_keyerror():
+    routes = [
+        (TOKEN_ROUTE, [_token_resp()]),
+        ("onlineMeetings?", [_FakeResp({"value": [{"id": "meeting-1"}]})]),
+        ("/transcripts", [_FakeResp({"value": [{"createdDateTime": "2026-07-01T00:00:00Z"}]})]),
+    ]
+    opener = _ScriptedOpener(routes)
+
+    with pytest.raises(GraphError) as exc:
+        fetch_meeting_vtt("t", "c", "s", "org1", "https://teams.microsoft.com/l/x", opener=opener)
+    assert "id" in str(exc.value)
+
+
+def test_fetch_meeting_vtt_transcripts_non_object_top_level_json_raises_graph_error():
+    routes = [
+        (TOKEN_ROUTE, [_token_resp()]),
+        ("onlineMeetings?", [_FakeResp({"value": [{"id": "meeting-1"}]})]),
+        ("/transcripts", [_FakeResp(b"[]")]),
+    ]
+    opener = _ScriptedOpener(routes)
+
+    with pytest.raises(GraphError):
+        fetch_meeting_vtt("t", "c", "s", "org1", "https://teams.microsoft.com/l/x", opener=opener)
+
+
+def test_fetch_meeting_vtt_missing_credentials_raises_graph_error_with_no_network_call():
+    calls = []
+
+    def opener(req, timeout=None):
+        calls.append(req)
+        raise AssertionError("no network call should have been made")
+
+    with pytest.raises(GraphError) as exc:
+        fetch_meeting_vtt("", "client1", "secret1", "organizer1",
+                          "https://teams.microsoft.com/l/x", opener=opener)
+    assert "Graph credentials not configured" in str(exc.value)
+    assert "PREPPIE_GRAPH_TENANT_ID" in str(exc.value)
+    assert calls == []
+
+
+def test_fetch_meeting_vtt_meeting_not_found_propagates():
+    routes = [
+        (TOKEN_ROUTE, [_token_resp()]),
+        ("onlineMeetings?", [_FakeResp({"value": []})]),
+    ]
+    opener = _ScriptedOpener(routes)
+
+    with pytest.raises(GraphError) as exc:
+        fetch_meeting_vtt("t", "c", "s", "org1", "https://teams.microsoft.com/l/x", opener=opener)
+    assert "meeting not found" in str(exc.value)
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/agent/transcript_fetch.py
+++ b/agent/transcript_fetch.py
@@ -1,0 +1,350 @@
+"""
+Preppie transcript fetch: authenticate to Microsoft Graph as an Entra app (client-credentials /
+app-only) and download a Teams meeting's transcript as WEBVTT text, which then feeds the existing
+parse_vtt -> run_spine pipeline (see agent.spine).
+
+Mirrors the defensive, injectable-opener + retry/backoff discipline of agent.spine.Backend and
+agent.reply_back.WebhookSender: the HTTP transport is injectable (an `opener` callable, default
+urllib.request.urlopen) so the whole module is unit-testable offline with zero network and zero
+credentials - see tests/test_transcript_fetch.py.
+"""
+from __future__ import annotations
+
+import email.utils
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any, Callable
+
+GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
+TOKEN_URL_TEMPLATE = "https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token"
+
+
+class GraphError(Exception):
+    """Raised for any unrecoverable Microsoft Graph / token-endpoint failure.
+
+    `status` is the originating HTTP status code when known (e.g. 403), else None - callers can
+    use it to append actionable, status-specific hints without re-parsing the message string.
+    """
+
+    def __init__(self, message: str, *, status: int | None = None):
+        super().__init__(message)
+        self.status = status
+
+
+_ACCESS_POLICY_HINT = (
+    "check the Teams application access policy (an admin must grant this app access via "
+    "New-CsApplicationAccessPolicy / Grant-CsApplicationAccessPolicy) and that "
+    "OnlineMeetingTranscript.Read.All has admin consent")
+
+
+def _quote_seg(value: str) -> str:
+    """URL-encode a single path segment (user id / meeting id / transcript id)."""
+    return urllib.parse.quote(str(value), safe="")
+
+
+# ---------- app-only token ----------
+def get_app_token(tenant_id: str, client_id: str, client_secret: str, *,
+                   opener: Callable | None = None,
+                   scope: str = "https://graph.microsoft.com/.default",
+                   attempts: int = 4) -> str:
+    """POST a client-credentials grant to the v2.0 token endpoint. Returns the access_token.
+
+    Raises GraphError with the Graph/AAD error_description on any failure (bad creds, network
+    error, malformed response). Retries transient failures (5xx from the token endpoint, or a
+    URLError/connection problem) with the same bounded backoff as GraphClient.get.
+    """
+    opener = opener or urllib.request.urlopen
+    attempts = (attempts if isinstance(attempts, int)
+                and not isinstance(attempts, bool) and attempts >= 1 else 1)
+    url = TOKEN_URL_TEMPLATE.format(tenant_id=tenant_id)
+    body = urllib.parse.urlencode({
+        "grant_type": "client_credentials",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "scope": scope,
+    }).encode()
+
+    for attempt in range(attempts):
+        req = urllib.request.Request(
+            url, data=body, method="POST",
+            headers={"Content-Type": "application/x-www-form-urlencoded"})
+        try:
+            with opener(req, timeout=30) as r:
+                raw = r.read()
+        except urllib.error.HTTPError as e:
+            if e.code >= 500 and attempt < attempts - 1:
+                time.sleep(1.5 * (attempt + 1))
+                continue
+            try:
+                err_body = json.loads(e.read().decode())
+            except Exception:
+                err_body = {}
+            msg = err_body.get("error_description") or err_body.get("error") or f"HTTP {e.code}"
+            raise GraphError(f"token request failed: {msg}") from e
+        except urllib.error.URLError as e:
+            if attempt < attempts - 1:
+                time.sleep(1.5 * (attempt + 1))
+                continue
+            raise GraphError(f"token request failed: connection error: {e}") from e
+        else:
+            break
+    else:
+        raise GraphError("token request failed: no request attempts made (attempts must be >= 1)")
+
+    try:
+        payload = json.loads(raw.decode())
+    except Exception as e:
+        raise GraphError(f"token request failed: could not parse response: {e}") from e
+
+    token = payload.get("access_token")
+    if not token:
+        msg = payload.get("error_description") or payload.get("error") or "no access_token in response"
+        raise GraphError(f"token request failed: {msg}")
+    return token
+
+
+# ---------- Graph HTTP client ----------
+class GraphClient:
+    """GETs Microsoft Graph URLs with a bearer token.
+
+    Mirrors agent.spine.Backend / agent.reply_back.WebhookSender: an injectable `opener` (default
+    urllib.request.urlopen) and a retry/backoff loop for transient failures (5xx, URLError, and
+    429 honoring Retry-After capped at 30s). Unlike those, `get()` DOES raise GraphError on
+    failure - callers of this module (find_meeting_id, list_transcripts, download_transcript_vtt,
+    fetch_meeting_vtt) want a hard stop with a clear message rather than a soft {"success": False}.
+    """
+
+    def __init__(self, token: str, *, opener: Callable | None = None, attempts: int = 4):
+        self.token = token
+        self._opener = opener or urllib.request.urlopen
+        self._attempts = (attempts if isinstance(attempts, int)
+                           and not isinstance(attempts, bool) and attempts >= 1 else 1)
+
+    def get(self, path_or_url: str, *, accept: str = "application/json") -> tuple[int, bytes]:
+        url = (path_or_url if path_or_url.startswith("http://") or path_or_url.startswith("https://")
+               else f"{GRAPH_BASE_URL}{path_or_url}")
+        headers = {"Authorization": f"Bearer {self.token}", "Accept": accept}
+
+        for attempt in range(self._attempts):
+            req = urllib.request.Request(url, method="GET", headers=headers)
+            try:
+                with self._opener(req, timeout=45) as r:
+                    status = getattr(r, "status", None)
+                    if status is None:
+                        status = getattr(r, "code", 200)
+                    resp_body = r.read()
+                    if 200 <= status < 300:
+                        return status, resp_body
+                    # A fake/test opener (or an unusual real one) may hand back a non-2xx
+                    # response directly instead of raising HTTPError - handle both paths
+                    # identically, same as WebhookSender.
+                    if status == 429 and attempt < self._attempts - 1:
+                        time.sleep(self._retry_after_wait(r, attempt))
+                        continue
+                    if status >= 500 and attempt < self._attempts - 1:
+                        time.sleep(1.5 * (attempt + 1))
+                        continue
+                    raise GraphError(self._graph_error_message(status, resp_body), status=status)
+            except urllib.error.HTTPError as e:
+                if e.code == 429 and attempt < self._attempts - 1:
+                    time.sleep(self._retry_after_wait(e, attempt))
+                    continue
+                if e.code >= 500 and attempt < self._attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                try:
+                    err_body = e.read()
+                except Exception:
+                    err_body = b""
+                raise GraphError(self._graph_error_message(e.code, err_body), status=e.code) from e
+            except urllib.error.URLError as e:
+                if attempt < self._attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                raise GraphError(f"connection error after {self._attempts} tries: {e}") from e
+        raise GraphError("no request attempts made (attempts must be >= 1)")
+
+    @staticmethod
+    def _graph_error_message(status: int, body: Any) -> str:
+        """Surface Graph's {"error": {"code", "message"}} shape if present, else a snippet."""
+        try:
+            raw = body.decode() if isinstance(body, (bytes, bytearray)) else str(body)
+        except Exception:
+            raw = ""
+        try:
+            parsed = json.loads(raw)
+            err = parsed.get("error")
+            if isinstance(err, dict) and (err.get("code") or err.get("message")):
+                return f"Graph API error (HTTP {status}): {err.get('code', '')} {err.get('message', '')}".strip()
+        except Exception:
+            pass
+        return f"HTTP {status}: {raw[:300]}"
+
+    @staticmethod
+    def _retry_after_wait(headers_source: Any, attempt: int) -> float:
+        """Compute the 429 backoff, honoring Retry-After (capped at 30s) if present.
+
+        `headers_source` may be an HTTPError (has `.headers`), a plain response object handed
+        back directly by an injected opener (also expected to expose `.headers`), or a raw
+        headers mapping.
+        """
+        if hasattr(headers_source, "headers"):
+            headers = getattr(headers_source, "headers", None)
+        else:
+            headers = headers_source
+        retry_after = None
+        try:
+            if headers is not None:
+                retry_after = headers.get("Retry-After")
+        except Exception:
+            retry_after = None
+        if retry_after:
+            try:
+                return min(float(retry_after), 30.0)
+            except (TypeError, ValueError):
+                pass
+            try:
+                dt = email.utils.parsedate_to_datetime(retry_after)
+                if dt is not None:
+                    if dt.tzinfo is None:
+                        dt = dt.replace(tzinfo=timezone.utc)
+                    delta = (dt - datetime.now(timezone.utc)).total_seconds()
+                    if delta > 0:
+                        return min(delta, 30.0)
+            except (TypeError, ValueError, OverflowError):
+                pass
+        return 1.5 * (attempt + 1)
+
+
+def _parse_graph_object(body: bytes, what: str) -> dict:
+    """Decode a Graph JSON response and require it to be a top-level object (not e.g. a bare
+    array), so callers can safely call .get(...) on it. Raises GraphError, never
+    AttributeError/KeyError, on any malformed-but-valid-JSON shape."""
+    try:
+        payload = json.loads(body.decode())
+    except Exception as e:
+        raise GraphError(f"could not parse {what} response: {e}") from e
+    if not isinstance(payload, dict):
+        raise GraphError(
+            f"unexpected {what} response shape: expected a JSON object, got "
+            f"{type(payload).__name__}")
+    return payload
+
+
+def _require_id(item: Any, what: str) -> str:
+    """Pull `id` out of a Graph list item, raising GraphError (not KeyError) if it's missing or
+    the item itself isn't an object."""
+    if not isinstance(item, dict) or not item.get("id"):
+        raise GraphError(f"{what} is missing an 'id' field in the Graph response: {item!r}")
+    return item["id"]
+
+
+def _append_403_hint(err: GraphError) -> GraphError:
+    """If `err` came from an HTTP 403, append the actionable access-policy/consent hint (the
+    same one find_meeting_id gives on a not-found, which is often *also* a 403-in-disguise)."""
+    if getattr(err, "status", None) == 403:
+        return GraphError(f"{err} - {_ACCESS_POLICY_HINT}", status=403)
+    return err
+
+
+# ---------- Graph lookups ----------
+def find_meeting_id(client: GraphClient, organizer_user_id: str, join_web_url: str) -> str:
+    """Resolve an onlineMeeting id from its join URL. Raises GraphError if none is found."""
+    safe_join_web_url = join_web_url.replace("'", "''")
+    filter_value = f"JoinWebUrl eq '{safe_join_web_url}'"
+    query = urllib.parse.urlencode({"$filter": filter_value})
+    path = f"/users/{_quote_seg(organizer_user_id)}/onlineMeetings?{query}"
+    try:
+        _, body = client.get(path)
+    except GraphError as e:
+        raise _append_403_hint(e) from e
+    payload = _parse_graph_object(body, "onlineMeetings")
+
+    meetings = payload.get("value") or []
+    if not meetings:
+        raise GraphError(
+            f"meeting not found for join URL {join_web_url!r} - either the URL/organizer is "
+            f"wrong, or the app is missing the application access policy that grants it access "
+            f"to this organizer's online meetings; {_ACCESS_POLICY_HINT}")
+    return _require_id(meetings[0], "the first onlineMeetings result")
+
+
+def list_transcripts(client: GraphClient, organizer_user_id: str, meeting_id: str) -> list[dict]:
+    """List transcripts for a meeting. An empty list is valid - transcription may still lag."""
+    path = f"/users/{_quote_seg(organizer_user_id)}/onlineMeetings/{_quote_seg(meeting_id)}/transcripts"
+    try:
+        _, body = client.get(path)
+    except GraphError as e:
+        raise _append_403_hint(e) from e
+    payload = _parse_graph_object(body, "transcripts")
+    return payload.get("value") or []
+
+
+def download_transcript_vtt(client: GraphClient, organizer_user_id: str, meeting_id: str,
+                             transcript_id: str) -> str:
+    """Download one transcript's content as WEBVTT text."""
+    path = (f"/users/{_quote_seg(organizer_user_id)}/onlineMeetings/{_quote_seg(meeting_id)}"
+            f"/transcripts/{_quote_seg(transcript_id)}/content?$format=text/vtt")
+    try:
+        _, body = client.get(path, accept="text/vtt")
+    except GraphError as e:
+        raise _append_403_hint(e) from e
+    try:
+        return body.decode("utf-8")
+    except Exception as e:
+        raise GraphError(f"could not decode transcript content as utf-8: {e}") from e
+
+
+# ---------- orchestration ----------
+def fetch_meeting_vtt(tenant_id: str, client_id: str, client_secret: str, organizer_user_id: str,
+                       join_web_url: str, *, opener: Callable | None = None,
+                       poll_attempts: int = 1, poll_seconds: float = 15) -> str:
+    """
+    Token -> GraphClient -> find_meeting_id -> list_transcripts -> pick the LATEST by
+    createdDateTime -> download its VTT.
+
+    If no transcripts are available yet and poll_attempts > 1, polls list_transcripts up to
+    poll_attempts times, sleeping poll_seconds between tries (transcription often lags a minute
+    or two after the meeting ends). Raises GraphError if still no transcript after polling.
+
+    Pre-flight: raises GraphError immediately (making NO network call at all) if any of the
+    required Graph credentials/config is empty, instead of firing a doomed request to e.g.
+    https://login.microsoftonline.com//oauth2/... with an empty tenant_id.
+    """
+    missing = [name for name, value in (
+        ("tenant_id", tenant_id), ("client_id", client_id),
+        ("client_secret", client_secret), ("organizer_user_id", organizer_user_id),
+    ) if not value]
+    if missing:
+        raise GraphError(
+            "Graph credentials not configured - set PREPPIE_GRAPH_TENANT_ID / "
+            "PREPPIE_GRAPH_CLIENT_ID / PREPPIE_GRAPH_CLIENT_SECRET / "
+            f"PREPPIE_GRAPH_ORGANIZER_USER_ID (missing: {', '.join(missing)})")
+
+    token = get_app_token(tenant_id, client_id, client_secret, opener=opener)
+    client = GraphClient(token, opener=opener)
+    meeting_id = find_meeting_id(client, organizer_user_id, join_web_url)
+
+    attempts = (poll_attempts if isinstance(poll_attempts, int)
+                and not isinstance(poll_attempts, bool) and poll_attempts >= 1 else 1)
+
+    transcripts: list[dict] = []
+    for attempt in range(attempts):
+        transcripts = list_transcripts(client, organizer_user_id, meeting_id)
+        if transcripts:
+            break
+        if attempt < attempts - 1:
+            time.sleep(poll_seconds)
+
+    if not transcripts:
+        raise GraphError(
+            f"no transcript available yet for meeting {meeting_id!r} after {attempts} attempt(s) "
+            "- transcription may still be processing; try again in a minute or two")
+
+    latest = max(transcripts, key=lambda t: (t.get("createdDateTime") or "") if isinstance(t, dict) else "")
+    latest_id = _require_id(latest, "the latest transcript")
+    return download_transcript_vtt(client, organizer_user_id, meeting_id, latest_id)

--- a/src/function_app.py
+++ b/src/function_app.py
@@ -287,8 +287,11 @@ def create_work_item(req: func.HttpRequest) -> func.HttpResponse:
                 mimetype="application/json"
             )
 
-        # Extract metadata from description if present (speaker, timestamp, meeting ID)
-        tags = []
+        # Tags carry the T-Minus-15 triage type when the process template has no native
+        # work item type for it (e.g. Enhancement -> Task+tag, Risk/Question -> Issue+tag).
+        tags = req_body.get("tags") or []
+        if isinstance(tags, str):
+            tags = [t.strip() for t in tags.split(";") if t.strip()]
         custom_fields = {}
 
         # Get DevOps client and create work item


### PR DESCRIPTION
## Summary

Adds the **meeting-capture** half of the brief: Preppie takes a Teams **join URL** and fetches that
meeting's transcript from Microsoft Graph — no manual VTT export. Combined with #78, one command
takes you from a meeting that happened to a triaged backlog.

```
teams join url → Graph: find meeting → poll for transcript → download VTT → spine (#78) → work items
```

`python -m agent.cli` now auto-detects what it's given: a Teams join URL (or `PREPPIE_MEETING_URL`)
goes down the Graph path, a local `.vtt` path still works exactly as before. An explicit argument
always wins.

## Issues Addressed

Delivers the post-meeting-transcript path we scoped as the spine of the trial (live media capture
deliberately out of scope — that needs ACS or an app-hosted media bot).

Related to #67, but explicitly **not** a fix for it: #67 is speaker diarization in the Speech
Services / media-bot path. Worth noting as an argument for this path though — Graph transcripts
carry Teams' own `<v Name>` voice tags, so speaker attribution is given rather than inferred, and
that class of bug doesn't arise.

## Key decisions (calling these out for review)

1. **App-only auth (client credentials), not delegated.** The agent needs to read transcripts for
   meetings it isn't a member of. That requires `OnlineMeetingTranscript.Read.All` +
   `OnlineMeetings.Read.All` as **application** permissions, admin-consented, **plus** a Teams
   application access policy (`New-CsApplicationAccessPolicy` / `Grant-CsApplicationAccessPolicy`) —
   without the policy, app-only transcript reads fail even with consent granted. Documented in the
   module docstring, since it's the step that silently bites you.

2. **Meeting lookup by `JoinWebUrl` filter, not meeting ID.** A join URL is what a human can actually
   copy out of a calendar invite; meeting IDs aren't discoverable from the UI. The OData filter value
   is quote-escaped (see robustness below).

3. **Polling, because transcripts lag.** Teams publishes the transcript some minutes after the
   meeting ends, so `fetch_meeting_vtt` polls rather than failing on the first empty result, and
   picks the most recent transcript when a meeting has several.

4. **Organizer identified by object ID, not UPN.** `/users/{id}/onlineMeetings` rejects a UPN with a
   400 ("not a valid GUID"). `PREPPIE_GRAPH_ORGANIZER_USER_ID` takes the directory object ID; the
   config docstring says so, because the error message doesn't.

5. **Credentials pre-flight.** Missing/blank Graph settings are caught up front with a clear message
   rather than surfacing as an opaque 401 several calls later.

## Key Changes

- `agent/transcript_fetch.py` — `get_app_token` (client credentials), `GraphClient` (retry, 429
  `Retry-After` incl. HTTP-date form), `find_meeting_id`, `list_transcripts`,
  `download_transcript_vtt` (`$format=text/vtt`, v1.0 GA), `fetch_meeting_vtt` (poll + pick latest +
  pre-flight).
- `agent/cli.py` — auto-detects join URL vs local `.vtt`; explicit arg wins.
- `agent/config.py` — `PREPPIE_GRAPH_TENANT_ID` / `_CLIENT_ID` / `_CLIENT_SECRET` /
  `_ORGANIZER_USER_ID`.
- `agent/tests/test_transcript_fetch.py` — 43 tests, HTTP layer injected (no network).

## Robustness

Two blockers found in review and fixed before this PR:

- **OData injection / 400s** — an apostrophe in a filter value broke the query; filter values are now
  properly single-quote-escaped.
- **Opaque failures** — malformed Graph responses raised raw `KeyError`/`AttributeError`; they now
  surface as `GraphError` with context.

Plus: 429 `Retry-After` honoured in both seconds and HTTP-date form, transient 5xx retried with
backoff, empty/absent transcript lists handled as "not ready yet" rather than as an error.

## Known limitations / follow-up

- Post-meeting only. Live capture needs a media layer (ACS or app-hosted media bot) — out of scope
  as agreed.
- The tenant setup (app registration, admin consent, Teams access policy) is manual and documented,
  not automated in Bicep. Worth automating if this goes to a real tenant.
- Transcription must be **on** for the meeting; no transcript, nothing to fetch.

## Test Plan

- [x] `python -m pytest agent/tests/ -q` → **58 passing**, no network.
- [x] Verified live end-to-end against a real transcribed Teams meeting: join URL → Graph fetch →
      spine → **12 work items (#29–#40)** in Azure DevOps covering all six capture types, hierarchy
      linked, owners attributed from speech → roll-up posted back into Teams.

```bash
python -m pytest agent/tests/ -q
python -m agent.cli "https://teams.microsoft.com/meet/..."   # Graph path
python -m agent.cli agent/tests/fixtures/sample-meeting.vtt  # local path, unchanged
```

## Note on branching

Branches off `feat/foundry-spine` (#78), so the diff is cleanest once that's merged — happy to
rebase onto `main` as soon as it goes in.

## Note on CI

The red checks are **fork-PR limits, not this code**: the Claude review action can't get an OIDC
token on PRs from forks, and `test.yml`'s "Comment PR" step can't post from a fork's read-only
token. The actual build/lint/test jobs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
