### PR TITLE
feat(agent): reply-back into Teams as an Adaptive Card (#30)

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,70 @@
+# Preppie spine — transcript → triaged Azure DevOps backlog
+
+The meeting-to-backlog core. A transcript goes in; a well-triaged, deduped, hierarchical Azure
+DevOps backlog comes out. This is the implementation of the Azure AI Foundry migration (#62) and
+the "actually reason over the transcript" behaviour (#27).
+
+## Architecture
+
+```
+transcript.vtt
+   │  parse_vtt (speaker attribution preserved)
+   ▼
+run_spine ──────────────► Azure AI Foundry (Responses API, gpt-5-mini)
+   ▲  function calls          │  instructions compiled from the T-Minus-15 workitems SKILL
+   │  tool outputs            ▼
+Backend (deployed Azure Functions) ──► Azure DevOps work items
+   read_projects · search_work_items (dedupe) · create_work_item · link_work_items
+```
+
+**Why the Responses API + a thin loop (not a middleware service).** The earlier design used an
+OpenAI resource-level *assistant*, whose function calls surface as a `requires_action` run that a
+separate long-running handler must service — the "missing piece" the old docs describe. The Foundry
+agent here uses the **Responses API**: `run_spine` is a stateless loop that receives the model's
+function calls, calls the deployed backend, and feeds the results back. No extra deployed component.
+
+**Why instructions are compiled, not hand-written.** `build_instructions.py` pulls the canonical
+sections (six work item types, triage, title hygiene, dedupe, reply-back) straight out of the
+T-Minus-15 `workitems` SKILL and wraps them with this deployment's runtime contract. The methodology
+stays the single source of truth; regenerate when it changes.
+
+## Model & type mapping
+
+- Model: **gpt-5-mini** (see `config.py`). gpt-4o is not deployable on this subscription's quota;
+  gpt-5-mini is current-gen and strong at tool-calling. One-line swap via `PREPPIE_MODEL`.
+- The Agile process template has native Task, Bug, Issue, Epic, Feature, User Story but **no**
+  Enhancement/Risk/Question type, so those map to Task/Issue **+ a tag** (`Enhancement`, `Risk`,
+  `Question`) — filterable, no custom process required. Full table in `preppie_instructions.md`.
+
+## Run it
+
+```bash
+# one-time: compile the instructions from a checkout of T-Minus-15/claude-plugins
+SKILLS_DIR=/path/to/claude-plugins/skills python agent/build_instructions.py > agent/preppie_instructions.md
+
+# run the spine over a transcript (uses your `az login` identity; no keys)
+python -m agent.cli path/to/meeting.vtt
+```
+
+Configuration (all optional, see `config.py`): `PREPPIE_FOUNDRY_OPENAI_ENDPOINT`, `PREPPIE_MODEL`,
+`PREPPIE_API_VERSION`, `PREPPIE_BACKEND_URL`, `PREPPIE_PROJECT`, `PREPPIE_INSTRUCTIONS_PATH`.
+
+## Tests
+
+```bash
+python -m pytest agent/tests/ -q
+```
+
+The backend and the LLM client are injected, so the parser, tool dispatch, and the full tool loop
+(dedupe-before-create, result collection, termination) are tested with no network access.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `spine.py` | `parse_vtt`, `Backend` (tool dispatch), `run_spine` (the loop) — the testable core |
+| `build_instructions.py` | compiles the system prompt from the T-Minus-15 SKILLs |
+| `preppie_instructions.md` | the compiled instructions (committed artifact) |
+| `config.py` | env-overridable deployment settings |
+| `cli.py` | wires the real Azure client + backend and runs a transcript |
+| `tests/` | unit tests + the sample transcript fixture |

--- a/agent/build_instructions.py
+++ b/agent/build_instructions.py
@@ -1,0 +1,102 @@
+"""
+Compile Preppie's agent instructions FROM the T-Minus-15 SKILL.md files.
+
+This is the heart of the Foundry migration (#62): the methodology is the source of truth, not a
+hand-maintained agent-config.json. We pull the canonical sections out of the `workitems` skill and
+wrap them with the deployment-specific runtime contract (tools, target project, the type ->
+Azure DevOps mapping for this process template, dedupe, hierarchy, reply-back, title hygiene).
+
+The T-Minus-15 skills live in a separate repo (T-Minus-15/claude-plugins). Point SKILLS_DIR at a
+checkout of it; the compiled result is committed alongside as `preppie_instructions.md` so the agent
+can be deployed without that checkout, and re-compiled whenever the methodology changes:
+
+    SKILLS_DIR=/path/to/claude-plugins/skills python agent/build_instructions.py > agent/preppie_instructions.md
+"""
+import os
+import re
+
+SKILLS = os.environ.get("SKILLS_DIR", os.path.expanduser("~/t-minus-15-claude-plugins/skills"))
+
+
+def section(skill: str, heading: str) -> str:
+    """Return the markdown block under a '## heading' (up to the next '## ') from a SKILL.md."""
+    path = os.path.join(SKILLS, skill, "SKILL.md")
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    text = re.sub(r"^---.*?---\n", "", text, count=1, flags=re.DOTALL)  # strip frontmatter
+    pat = re.compile(rf"^##\s+{re.escape(heading)}\s*$(.*?)(?=^##\s|\Z)", re.MULTILINE | re.DOTALL)
+    m = pat.search(text)
+    if not m:
+        raise SystemExit(f"[build] section '{heading}' not found in {skill}/SKILL.md")
+    return f"## {heading}\n{m.group(1).rstrip()}\n"
+
+
+HEADER = """# Preppie the Prepper - agent instructions
+
+You are **Preppie the Prepper**, the T-Minus-15 requirements/backlog agent. You turn a meeting
+transcript into a clean, well-triaged Azure DevOps backlog. You are precise, never invent facts,
+and you follow the T-Minus-15 methodology below (these rules are compiled from the T-Minus-15
+`workitems` skill and its per-type skills - they are the source of truth).
+
+## Your job for each run
+1. Read the transcript. Enumerate every actionable item raised, with who raised it and any owner.
+2. Triage each item to a type (see "The six work item types" + "Triage" below).
+3. Build the backlog structure (Epic -> Feature -> User Story) when the discussion implies it, and
+   attach the captured items under the right parent.
+4. BEFORE creating anything, DEDUPE: call `search_work_items` (titleContains) to check the item
+   doesn't already exist. Skip creation if a clear match exists; say so in your summary.
+5. Create each item with `create_work_item`, then link children to parents with `link_work_items`.
+6. End with a reply-back roll-up table mapping each thing raised -> what you logged (see format).
+
+## Runtime contract (this deployment)
+- Target project is **"Preppie"** in Azure DevOps org `ayush866`. Confirm with `read_projects`
+  if unsure; do not assume any other project.
+- You act ONLY through the provided tools. Never fabricate work item IDs or URLs - use what the
+  `create_work_item` tool returns.
+- **Type -> Azure DevOps mapping** (this project's Agile process template has native Task, Bug,
+  Issue, Epic, Feature, User Story - but NO native Enhancement/Risk/Question type). Map as:
+  | Triage type | `type` to pass | `tags` to pass |
+  |---|---|---|
+  | Task | `Task` | - |
+  | Bug | `Bug` | - |
+  | Issue | `Issue` | - |
+  | Enhancement | `Task` | `["Enhancement"]` |
+  | Risk | `Issue` | `["Risk"]` |
+  | Question | `Issue` | `["Question"]` |
+  | Epic / Feature / User Story | `Epic` / `Feature` / `User Story` | - |
+  Always set the tag when the mapping requires it, so the item stays filterable as its real type.
+- **Linking - attach to the nearest relevant parent.** Link every captured item to the MOST
+  specific parent that fits: a User Story if one applies, otherwise its Feature, otherwise the
+  Epic. A Bug/Task/Enhancement that affects a specific story must hang off that User Story, not the
+  Epic, when such a story exists.
+- Pass acceptance criteria ONLY on User Stories, via `acceptanceCriteria` (a list of strings), in
+  AMP form (Acceptance / Measure / Proof).
+- Keep descriptions rich enough that someone picking the item up cold understands it: what was
+  said, who raised it, why, and what "done" looks like. Never log a bare title.
+
+## Title hygiene (deployment-specific)
+- **Do NOT prefix a title with its type** ("Risk:", "Question:", "Bug:" ...). The work item type
+  and tag already convey that - the title states the thing itself.
+- Otherwise follow the "Title hygiene (all types)" rules below.
+
+## Output
+When all items are logged, output ONLY the reply-back summary described in "Reply-back convention"
+below: a one-line-per-item list, then the roll-up cross-reference table. Note any renames (title
+hygiene) and any items you skipped as duplicates.
+"""
+
+
+def compile_instructions() -> str:
+    parts = [HEADER, "\n---\n\n# Methodology (compiled from the T-Minus-15 skills)\n"]
+    parts.append(section("workitems", "Safety rules (before you log anything)"))
+    parts.append(section("workitems", "The six work item types"))
+    parts.append(section("workitems", "Triage: deciding the type"))
+    parts.append(section("workitems", "Capture flow (meetings & stand-ups)"))
+    parts.append(section("workitems", "Title hygiene (all types)"))
+    parts.append(section("workitems", "Writing the description"))
+    parts.append(section("workitems", "Reply-back convention (important)"))
+    return "\n\n".join(p.strip() for p in parts)
+
+
+if __name__ == "__main__":
+    print(compile_instructions())

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -1,0 +1,43 @@
+"""
+Run the Preppie spine over a transcript file:
+
+    python -m agent.cli path/to/meeting.vtt
+
+Authenticates to Azure AI Foundry with your `az login` identity (DefaultAzureCredential), so no
+keys are handled here. Reads deployment settings from agent/config.py (env-overridable).
+"""
+import sys
+
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from openai import AzureOpenAI
+
+from . import config
+from .spine import Backend, read_transcript, run_spine
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: python -m agent.cli <transcript.vtt>", file=sys.stderr)
+        return 2
+
+    transcript = read_transcript(argv[1])
+    with open(config.INSTRUCTIONS_PATH, encoding="utf-8") as f:
+        instructions = f.read()
+
+    token_provider = get_bearer_token_provider(DefaultAzureCredential(), config.TOKEN_SCOPE)
+    client = AzureOpenAI(azure_endpoint=config.FOUNDRY_OPENAI_ENDPOINT,
+                         azure_ad_token_provider=token_provider, api_version=config.API_VERSION)
+    backend = Backend(config.BACKEND_URL, config.PROJECT)
+
+    result = run_spine(transcript, instructions, client, backend, config.MODEL,
+                       on_event=lambda m: print(f"  [tool] {m}", flush=True))
+
+    print("\n===================== PREPPIE REPLY-BACK =====================\n")
+    print(result["reply_back"])
+    print(f"\n[summary] created {len(result['created'])} work items in '{config.PROJECT}' "
+          f"over {result['turns']} turns.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -12,6 +12,7 @@ from azure.identity import DefaultAzureCredential, get_bearer_token_provider
 from openai import AzureOpenAI
 
 from . import config
+from .reply_back import WebhookSender, post_reply_back
 from .spine import Backend, read_transcript, run_spine
 
 
@@ -36,6 +37,17 @@ def main(argv: list[str]) -> int:
     print(result["reply_back"])
     print(f"\n[summary] created {len(result['created'])} work items in '{config.PROJECT}' "
           f"over {result['turns']} turns.")
+
+    if config.TEAMS_WEBHOOK_URL.strip():
+        post = post_reply_back(result, WebhookSender(config.TEAMS_WEBHOOK_URL),
+                               board_url=config.BOARD_URL or None)
+        if post["sent"]:
+            print(f"[teams] reply-back posted to Teams (status {post['status']}).")
+        else:
+            print(f"[teams] failed to post reply-back to Teams: {post['error']}")
+    else:
+        print("[teams] skipped posting to Teams (no PREPPIE_TEAMS_WEBHOOK_URL configured).")
+
     return 0
 
 

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,26 @@
+"""Deployment configuration for the Preppie spine - all overridable via environment variables."""
+import os
+
+# Azure AI Foundry resource's Azure OpenAI endpoint (Responses API lives here).
+FOUNDRY_OPENAI_ENDPOINT = os.environ.get(
+    "PREPPIE_FOUNDRY_OPENAI_ENDPOINT", "https://preppie-foundry-ayush866.openai.azure.com/")
+
+# Model deployment name on that resource.
+MODEL = os.environ.get("PREPPIE_MODEL", "gpt-5-mini")
+
+# API version that exposes the Responses API.
+API_VERSION = os.environ.get("PREPPIE_API_VERSION", "2025-04-01-preview")
+
+# Deployed Azure Functions backend (the Azure DevOps tool surface).
+BACKEND_URL = os.environ.get(
+    "PREPPIE_BACKEND_URL", "https://preppie-backend-ayush866-prod.azurewebsites.net")
+
+# Target Azure DevOps project.
+PROJECT = os.environ.get("PREPPIE_PROJECT", "Preppie")
+
+# Compiled agent instructions (see build_instructions.py).
+INSTRUCTIONS_PATH = os.environ.get(
+    "PREPPIE_INSTRUCTIONS_PATH", os.path.join(os.path.dirname(__file__), "preppie_instructions.md"))
+
+# AAD scope for the Foundry data plane.
+TOKEN_SCOPE = os.environ.get("PREPPIE_TOKEN_SCOPE", "https://cognitiveservices.azure.com/.default")

--- a/agent/config.py
+++ b/agent/config.py
@@ -24,3 +24,10 @@ INSTRUCTIONS_PATH = os.environ.get(
 
 # AAD scope for the Foundry data plane.
 TOKEN_SCOPE = os.environ.get("PREPPIE_TOKEN_SCOPE", "https://cognitiveservices.azure.com/.default")
+
+# Teams Incoming Webhook / Power Automate Workflows URL to post the meeting reply-back into.
+# Empty (the default) means Teams posting is skipped entirely - no credentials required.
+TEAMS_WEBHOOK_URL = os.environ.get("PREPPIE_TEAMS_WEBHOOK_URL", "")
+
+# Optional link to the Azure DevOps board, added as an "Open board" action on the reply-back card.
+BOARD_URL = os.environ.get("PREPPIE_BOARD_URL", "")

--- a/agent/preppie_instructions.md
+++ b/agent/preppie_instructions.md
@@ -1,0 +1,141 @@
+# Preppie the Prepper - agent instructions
+
+You are **Preppie the Prepper**, the T-Minus-15 requirements/backlog agent. You turn a meeting
+transcript into a clean, well-triaged Azure DevOps backlog. You are precise, never invent facts,
+and you follow the T-Minus-15 methodology below (these rules are compiled from the T-Minus-15
+`workitems` skill and its per-type skills - they are the source of truth).
+
+## Your job for each run
+1. Read the transcript. Enumerate every actionable item raised, with who raised it and any owner.
+2. Triage each item to a type (see "The six work item types" + "Triage" below).
+3. Build the backlog structure (Epic -> Feature -> User Story) when the discussion implies it, and
+   attach the captured items under the right parent.
+4. BEFORE creating anything, DEDUPE: call `search_work_items` (titleContains) to check the item
+   doesn't already exist. Skip creation if a clear match exists; say so in your summary.
+5. Create each item with `create_work_item`, then link children to parents with `link_work_items`.
+6. End with a reply-back roll-up table mapping each thing raised -> what you logged (see format).
+
+## Runtime contract (this deployment)
+- Target project is **"Preppie"** in Azure DevOps org `ayush866`. Confirm with `read_projects`
+  if unsure; do not assume any other project.
+- You act ONLY through the provided tools. Never fabricate work item IDs or URLs - use what the
+  `create_work_item` tool returns.
+- **Type -> Azure DevOps mapping** (this project's Agile process template has native Task, Bug,
+  Issue, Epic, Feature, User Story - but NO native Enhancement/Risk/Question type). Map as:
+  | Triage type | `type` to pass | `tags` to pass |
+  |---|---|---|
+  | Task | `Task` | - |
+  | Bug | `Bug` | - |
+  | Issue | `Issue` | - |
+  | Enhancement | `Task` | `["Enhancement"]` |
+  | Risk | `Issue` | `["Risk"]` |
+  | Question | `Issue` | `["Question"]` |
+  | Epic / Feature / User Story | `Epic` / `Feature` / `User Story` | - |
+  Always set the tag when the mapping requires it, so the item stays filterable as its real type.
+- **Linking - attach to the nearest relevant parent.** Link every captured item to the MOST
+  specific parent that fits: a User Story if one applies, otherwise its Feature, otherwise the
+  Epic. A Bug/Task/Enhancement that affects a specific story must hang off that User Story, not the
+  Epic, when such a story exists.
+- Pass acceptance criteria ONLY on User Stories, via `acceptanceCriteria` (a list of strings), in
+  AMP form (Acceptance / Measure / Proof).
+- Keep descriptions rich enough that someone picking the item up cold understands it: what was
+  said, who raised it, why, and what "done" looks like. Never log a bare title.
+
+## Title hygiene (deployment-specific)
+- **Do NOT prefix a title with its type** ("Risk:", "Question:", "Bug:" ...). The work item type
+  and tag already convey that - the title states the thing itself.
+- Otherwise follow the "Title hygiene (all types)" rules below.
+
+## Output
+When all items are logged, output ONLY the reply-back summary described in "Reply-back convention"
+below: a one-line-per-item list, then the roll-up cross-reference table. Note any renames (title
+hygiene) and any items you skipped as duplicates.
+
+---
+
+# Methodology (compiled from the T-Minus-15 skills)
+
+## Safety rules (before you log anything)
+
+Logging into a shared tracker is easy to get wrong in ways that are hard to undo. Always:
+
+1. **Check before you create** — query the tracker first to avoid duplicate items. Duplicates cause confusion and waste effort.
+2. **Never hard-delete** — set state to "Removed"/closed instead. Deletion is irreversible and loses history.
+3. **Don't quietly amend an active Epic's backlog** — adding/removing Features on an Epic already underway changes the scope of in-progress work. Confirm with the requester (and, for client work, the customer) first.
+4. **Ask when unsure** — if you're not certain of the project, area path, owner, or whether something should be created at all, ask before acting (`AskUserQuestion`).
+
+## The six work item types
+
+| Type | Use for | Skill |
+|------|---------|-------|
+| **Task** | A concrete action/to-do with a clear owner | `task` |
+| **Bug** | Something is broken vs expected behaviour | `bug` |
+| **Enhancement** | Improve existing functionality | `enhancement` |
+| **Risk** | Something that *might* go wrong (impact + mitigation) | `risk` |
+| **Issue** | Something that *is* going wrong / a blocker (impact + resolution) | `issue` |
+| **Question** | A clarification needed before work can proceed (needs an owner) | `question` |
+
+(Epics, Features and User Stories are backlog structure — use the `epic`, `feature`, `user-story` skills for those.)
+
+## Triage: deciding the type
+
+For each item raised, ask:
+1. Is it broken right now? → **Bug** (or **Issue** if it's a process/delivery blocker rather than a code defect).
+2. Is it a "might happen" concern? → **Risk** (capture impact + mitigation).
+3. Is it "make the existing thing better"? → **Enhancement**.
+4. Is it an open question blocking progress? → **Question** (assign an owner).
+5. Otherwise, a plain action with an owner → **Task**.
+
+When the type is genuinely ambiguous, use `AskUserQuestion` rather than guessing.
+
+## Capture flow (meetings & stand-ups)
+
+1. **Read the source** — meeting chat, transcript, or notes. Enumerate each actionable item with who raised it and any owner mentioned.
+2. **Scope discipline** — only log the items you've been explicitly asked to. For items raised by *other* people, or where ownership is unclear, **flag and confirm before logging** — do not assume. ("These three are yours; I'll log them. Two others were raised by colleagues — want me to log those too?")
+3. **Decide the type** for each (triage above).
+4. **Sanitise the title** (see Title hygiene) — professional, client-safe wording.
+5. **Write a meaningful description** (see Writing the description). If the item was raised in a meeting, **read the meeting transcript / chat / notes** — or delegate a sub-agent via `Task` — to capture the context, decisions and acceptance detail, rather than logging a bare one-liner.
+6. **Log** each item in the tracker (title + description + owner + parent link).
+7. **Reply back** in the thread, and **summarise** to the requester (see Reply-back convention).
+
+## Title hygiene (all types)
+
+Every work item title must be **safe to share with a client** and professional, regardless of how it's created (including ad-hoc via `az boards`):
+- Rephrase internal slang/shorthand — "Chase X" → "Follow up X".
+- Prefer a **role or company** over an individual's personal name where possible.
+- Avoid HR/immigration/visa specifics, and commercially sensitive detail (rates, margins).
+- Keep it concise and outcome-oriented.
+
+If you change the wording from what was said, note it in the reply-back (so the requester can see "Chase HRB" was logged as "Follow up HRB").
+
+## Writing the description
+
+A work item is only useful if its description carries the context — **don't leave it blank or log just a title.**
+
+- **Aim for enough detail that someone picking it up cold understands it** — the background, what "done" looks like, and any links (related work items, documents, the PR/repo).
+- **Meeting-created items:** if it came out of a meeting or stand-up, **look at the transcript / chat / notes** to enrich the description — who asked for it, why, and any decisions or acceptance detail discussed. For a long transcript, **delegate a sub-agent via `Task`** to read it and draft the description, then review before logging.
+- **Match the type's fields** (see Per-type specifics) — a Bug needs repro steps; a Risk needs impact + mitigation; etc.
+- Keep it client-safe (same rules as titles).
+
+## Reply-back convention (important)
+
+After logging, do **two** reply-backs:
+
+**1. In the meeting thread / chat** — quote the person's original comment and reply with the linked item, so the action and its tracker entry sit together:
+
+> [Task 1234](https://dev.azure.com/<your-org>/<project>/_workitems/edit/1234): Create partnership document (`<project>`)
+
+Format: **`[<Type> <ID>](url): <Title> (<project>[ — assigned to <name>])`**, where `<Type> <ID>` is the hyperlink. Append the assignee when it's someone other than the requester.
+
+**2. Summarise back to the requester** — one line per item, then a roll-up table:
+
+> - **#1234 — Create partnership document** (Task, `<project>`, assigned to <name>, State: New) — [open](https://.../edit/1234)
+
+Roll-up + cross-reference table (so each thing raised maps to what was logged):
+
+> | Raised | Logged as | Link |
+> |---|---|---|
+> | Create partnership doc | Task **1234** | [edit/1234](https://.../edit/1234) |
+> | Chase supplier for quote | Task **1235** (titled "Follow up supplier quote") | [edit/1235](https://.../edit/1235) |
+
+Use ✅ to confirm an *action completed* ("Logged and posted ✅"), not as a per-item prefix.

--- a/agent/reply_back.py
+++ b/agent/reply_back.py
@@ -1,0 +1,415 @@
+"""
+Preppie reply-back (#30): post the spine's meeting-backlog summary into a Teams channel as an
+Adaptive Card, via a Teams Incoming Webhook / Workflows URL.
+
+Mirrors the defensive, never-raises discipline of agent.spine.Backend._request: the HTTP
+transport is injectable (an `opener` callable, default urllib.request.urlopen) so the whole
+module is unit-testable offline with zero network and zero credentials - see
+tests/test_reply_back.py.
+"""
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+import urllib.error
+from typing import Any, Callable
+from urllib.parse import quote
+
+# Teams (Workflows / Incoming Webhook) rejects payloads over roughly 28KB. Capping the number of
+# listed items keeps the card comfortably under that even for a very large meeting backlog.
+DEFAULT_MAX_ITEMS = 20
+
+# --- size guards (layers a/b/c against the ~28KB Teams card limit) ---
+# (a) per-title cap, applied in _item_line.
+MAX_TITLE_CHARS = 200
+# (b) reply_back cap, applied in build_adaptive_card - the LLM's free-form final message is
+# otherwise unbounded and a single verbose reply can blow the card past the limit on its own.
+MAX_REPLY_BACK_CHARS = 3500
+# Header text also comes from caller-supplied `meeting_title`; cap it too so a pathological
+# caller can't defeat the guarantee below via that field.
+MAX_HEADER_CHARS = 300
+# (c) final hard guard: after assembling the whole card, we keep trimming body content until the
+# serialized card is under this budget (a little short of the real ~28KB limit for safety
+# margin), regardless of how (a) and (b) were bypassed or what nonsense `max_items` is. This is
+# the layer that GUARANTEES the cap - (a) and (b) just make it rarely have to do any work.
+MAX_CARD_BYTES = 26000
+
+# urllib.parse.quote's "safe" set for URLs we re-embed in Adaptive Card markdown link syntax:
+# keep URL-structural characters literal (so a normal https://host/path?a=b#frag round-trips
+# unchanged) but percent-encode anything that would break the `(...)` markdown link syntax, most
+# importantly spaces, unescaped parens, and raw unicode. "%" is kept safe so an already-encoded
+# URL is not double-encoded.
+_URL_SAFE_CHARS = ":/?#[]@!$&'()*+,;=%~"
+
+_DEFAULT_HEADER = "🗂️ Preppie — meeting backlog"
+_EMPTY_TEXT = "No backlog items were created from this meeting."
+
+
+# ---------- small, dependency-free helpers ----------
+def _pluralize(word: str) -> str:
+    """Best-effort plural of a work item type name ('Bug' -> 'Bugs', 'Story' -> 'Stories')."""
+    if not word:
+        return word
+    if word.endswith("y") and len(word) > 1 and word[-2].lower() not in "aeiou":
+        return word[:-1] + "ies"
+    if word.endswith(("s", "x", "sh", "ch")):
+        return word + "es"
+    return word + "s"
+
+
+def _clean_text(value: Any, default: str = "") -> str:
+    """Coerce anything to a single-line-ish plain string. Never raises."""
+    try:
+        if value is None:
+            return default
+        s = value if isinstance(value, str) else str(value)
+        s = s.replace("\r\n", " ").replace("\r", " ").replace("\n", " ").strip()
+        return s if s else default
+    except Exception:
+        return default
+
+
+def _as_dict(value: Any) -> dict:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list:
+    return value if isinstance(value, list) else []
+
+
+def _normalize_result(result: Any) -> tuple[list, str]:
+    """Defensively pull (created_items, reply_back_text) out of a possibly-malformed result."""
+    result = _as_dict(result)
+    created = [_as_dict(item) for item in _as_list(result.get("created"))]
+    reply_back = result.get("reply_back")
+    reply_back = reply_back.strip() if isinstance(reply_back, str) else _clean_text(reply_back, "")
+    return created, reply_back
+
+
+def _quote_url(url: str) -> str:
+    """Percent-encode a URL for safe interpolation into '(...)' markdown link syntax. A raw space
+    or unescaped paren in the URL would otherwise break the link (nothing renders as clickable)."""
+    try:
+        return quote(url, safe=_URL_SAFE_CHARS)
+    except Exception:
+        return url
+
+
+def _item_line(item: dict) -> str:
+    """'- **{type} #{id}** [{title}](url)' with defensive fallbacks for any missing field.
+
+    Note the intentional asymmetry with reply_back (see build_adaptive_card): titles are
+    flattened to single-line labels here, while reply_back keeps its newlines as prose.
+    """
+    item = _as_dict(item)
+    wtype = _clean_text(item.get("work_item_type"), "Item")
+    wid = item.get("work_item_id")
+    wid_str = _clean_text(wid, "?") if wid is not None else "?"
+    title = _clean_text(item.get("title"), "(untitled)")
+    if len(title) > MAX_TITLE_CHARS:
+        title = title[:MAX_TITLE_CHARS] + "…"
+    # Escape markdown link brackets in the title so an unbalanced "]" can't break the rest of the
+    # line, and so an embedded "[text](some-other-url)" snippet (e.g. copied from a transcript)
+    # can never hijack the bullet's clickable target away from the real work-item url.
+    title = title.replace("[", "\\[").replace("]", "\\]")
+    url = item.get("url")
+    url = url.strip() if isinstance(url, str) and url.strip() else None
+    if url:
+        return f"- **{wtype} #{wid_str}** [{title}]({_quote_url(url)})"
+    return f"- **{wtype} #{wid_str}** {title}"
+
+
+def _breakdown(created: list) -> str:
+    """'1 Epic · 2 Features · 1 Bug' - grouped by work_item_type, first-seen order."""
+    counts: dict[str, int] = {}
+    for item in created:
+        wtype = _clean_text(_as_dict(item).get("work_item_type"), "Item")
+        counts[wtype] = counts.get(wtype, 0) + 1
+    parts = []
+    for wtype, n in counts.items():
+        label = wtype if n == 1 else _pluralize(wtype)
+        parts.append(f"{n} {label}")
+    return " · ".join(parts)
+
+
+def _text_block(text: str, **extra: Any) -> dict:
+    block = {"type": "TextBlock", "text": text, "wrap": True}
+    block.update(extra)
+    return block
+
+
+def _minimal_card(header_text: str) -> dict:
+    return {
+        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+        "type": "AdaptiveCard",
+        "version": "1.4",
+        "body": [_text_block(header_text, weight="Bolder", size="Medium")],
+    }
+
+
+def _clamp_max_items(value: Any) -> int:
+    # bool is an int subclass (isinstance(True, int) is True) - exclude it explicitly so
+    # max_items=True doesn't silently get treated as max_items=1.
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return DEFAULT_MAX_ITEMS
+
+
+def _clean_url(url: Any) -> str | None:
+    return url.strip() if isinstance(url, str) and url.strip() else None
+
+
+def _card_bytes(card: dict) -> int:
+    try:
+        return len(json.dumps(card).encode())
+    except Exception:
+        return MAX_CARD_BYTES + 1  # force further trimming/fallback rather than silently pass
+
+
+# ---------- public API ----------
+def build_adaptive_card(result: dict, *, meeting_title: str | None = None,
+                         board_url: str | None = None, max_items: int = DEFAULT_MAX_ITEMS) -> dict:
+    """
+    Build a valid Adaptive Card (1.4) JSON dict summarizing a run_spine() result. Never raises -
+    on a malformed/empty `result` it still returns a minimal valid card.
+
+    Guarantees the serialized card stays under MAX_CARD_BYTES (Teams' ~28KB card limit) no matter
+    how large `result` is: titles and reply_back are pre-truncated, and as a final hard guard the
+    body is trimmed (dropping item lines, then reply_back) until it fits - so a single oversized
+    title or reply_back can never sink the whole post and lose every created-item's info.
+    """
+    header_text = _clean_text(meeting_title, "") or _DEFAULT_HEADER
+    if len(header_text) > MAX_HEADER_CHARS:
+        header_text = header_text[:MAX_HEADER_CHARS] + "…"
+    try:
+        created, reply_back = _normalize_result(result)
+        cap = _clamp_max_items(max_items)
+        total = len(created)
+        visible = created[:cap]
+        count_truncated = total > cap
+        extra_count = total - cap if count_truncated else 0
+
+        b_url = _clean_url(board_url)
+        b_url_q = _quote_url(b_url) if b_url else None
+
+        header_block = _text_block(header_text, weight="Bolder", size="Medium")
+        summary_text = _EMPTY_TEXT if total == 0 else f"{total} work item(s) created: {_breakdown(created)}"
+        summary_block = _text_block(summary_text, isSubtle=True)
+
+        item_blocks = [_text_block(_item_line(item)) for item in visible]
+
+        more_block = None
+        if count_truncated:
+            more = f"+{extra_count} more — see the full board"
+            if b_url_q:
+                more = f"[{more}]({b_url_q})"
+            more_block = _text_block(more, isSubtle=True)
+
+        reply_back_block = None
+        if reply_back:
+            # reply_back is the LLM's own free-form final message (prose) - unlike titles above
+            # (flattened to single-line labels), we deliberately keep its newlines. Known display
+            # limitation: if reply_back contains a markdown pipe-table, Adaptive Card TextBlocks
+            # can't render tables, so it shows as raw text, not a table. That's acceptable because
+            # the structured item list built above is the reliable representation of what was
+            # created; reply_back is just supplementary color.
+            rb = reply_back
+            if len(rb) > MAX_REPLY_BACK_CHARS:
+                rb = rb[:MAX_REPLY_BACK_CHARS] + "… (truncated — see the full board)"
+            reply_back_block = _text_block(rb)
+
+        def assemble() -> dict:
+            body = [header_block, summary_block, *item_blocks]
+            if more_block:
+                body.append(more_block)
+            if reply_back_block:
+                body.append(reply_back_block)
+            c: dict[str, Any] = {
+                "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                "type": "AdaptiveCard",
+                "version": "1.4",
+                "body": body,
+            }
+            if b_url_q:
+                c["actions"] = [{"type": "Action.OpenUrl", "title": "Open board", "url": b_url_q}]
+            return c
+
+        card = assemble()
+
+        # (c) Final hard guard: drop trailing item lines, then reply_back, until it fits - this is
+        # what actually guarantees the cap regardless of what (a)/(b) or a huge max_items let through.
+        trimmed = False
+        while _card_bytes(card) > MAX_CARD_BYTES and (item_blocks or reply_back_block is not None):
+            trimmed = True
+            if item_blocks:
+                item_blocks.pop()
+            else:
+                reply_back_block = None
+            card = assemble()
+
+        if trimmed:
+            note_text = "(some items trimmed — see the full board)"
+            if b_url_q:
+                note_text = f"[{note_text}]({b_url_q})"
+            card["body"].append(_text_block(note_text, isSubtle=True))
+
+            if _card_bytes(card) > MAX_CARD_BYTES:
+                # Pathological case (e.g. a huge breakdown/summary line) - collapse to the bare
+                # minimum. The created-item counts (summary_block) are always kept: that's the
+                # one piece of info this function must never lose.
+                card["body"] = [header_block, summary_block,
+                                 _text_block("(details omitted — see the full board)", isSubtle=True)]
+                if _card_bytes(card) > MAX_CARD_BYTES:
+                    # Still too big only if header/summary themselves are enormous - shrink those too.
+                    card["body"] = [
+                        _text_block(header_text[:200], weight="Bolder", size="Medium"),
+                        _text_block(summary_text[:200], isSubtle=True),
+                    ]
+
+        return card
+    except Exception:
+        return _minimal_card(header_text)
+
+
+class WebhookSender:
+    """POSTs an Adaptive Card to a Teams Incoming Webhook / Power Automate Workflows URL.
+
+    Mirrors agent.spine.Backend: an injectable `opener` (default urllib.request.urlopen), a
+    retry/backoff loop for transient failures, and a `send()` that never raises.
+    """
+
+    def __init__(self, url: str | None, opener: Callable | None = None, attempts: int = 4):
+        self.url = url
+        self._opener = opener or urllib.request.urlopen
+        self._attempts = attempts
+
+    def send(self, card: dict) -> dict:
+        if not isinstance(self.url, str) or not self.url.strip():
+            return {"sent": False, "status": None, "error": "no webhook url configured"}
+
+        envelope = {
+            "type": "message",
+            "attachments": [{
+                "contentType": "application/vnd.microsoft.card.adaptive",
+                "content": card,
+            }],
+        }
+        try:
+            data = json.dumps(envelope).encode()
+        except Exception as e:
+            return {"sent": False, "status": None, "error": f"could not encode card: {e}"}
+
+        attempts = (self._attempts if isinstance(self._attempts, int)
+                    and not isinstance(self._attempts, bool) and self._attempts >= 1 else 0)
+        for attempt in range(attempts):
+            req = urllib.request.Request(
+                self.url, data=data, method="POST",
+                headers={"Content-Type": "application/json"})
+            try:
+                with self._opener(req, timeout=15) as r:
+                    status = getattr(r, "status", None)
+                    if status is None:
+                        status = getattr(r, "code", 200)
+                    try:
+                        r.read()
+                    except Exception:
+                        pass
+                    if 200 <= status < 300:
+                        return {"sent": True, "status": status, "error": None}
+                    # Most openers raise HTTPError for >=400 instead of returning here, but a
+                    # fake/test opener may hand back a non-2xx (or even non-3xx-successful, e.g.
+                    # a bare 300) response object directly - treat anything outside 2xx as not
+                    # sent, same as the HTTPError path below.
+                    if status >= 500 and attempt < attempts - 1:
+                        time.sleep(1.5 * (attempt + 1))
+                        continue
+                    if status == 429 and attempt < attempts - 1:
+                        # Direct-response 429 (no exception raised) must honor Retry-After
+                        # identically to the HTTPError branch below.
+                        time.sleep(self._retry_after_wait(r, attempt))
+                        continue
+                    return {"sent": False, "status": status, "error": f"HTTP {status}"}
+            except urllib.error.HTTPError as e:
+                if e.code == 429 and attempt < attempts - 1:
+                    time.sleep(self._retry_after_wait(e, attempt))
+                    continue
+                if e.code >= 500 and attempt < attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                try:
+                    body = e.read().decode()[:300]
+                except Exception:
+                    body = ""
+                return {"sent": False, "status": e.code, "error": f"HTTP {e.code}: {body}"}
+            except urllib.error.URLError as e:
+                if attempt < attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                return {"sent": False, "status": None,
+                        "error": f"connection error after {attempts} tries: {e}"}
+            except Exception as e:
+                # Belt-and-braces: an unexpected opener failure must never propagate out of send().
+                if attempt < attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                return {"sent": False, "status": None, "error": f"unexpected error: {e}"}
+        return {"sent": False, "status": None, "error": "no request attempts made (attempts must be >= 1)"}
+
+    @staticmethod
+    def _retry_after_wait(headers_source: Any, attempt: int) -> float:
+        """Compute the 429 backoff, honoring Retry-After (capped at 30s) if present.
+
+        `headers_source` may be an HTTPError (has `.headers`), a plain response object handed
+        back directly by an injected opener (also expected to expose `.headers`), or a raw
+        headers mapping - so both the "opener raised HTTPError" and the "opener returned a 429
+        response object" paths honor Retry-After identically.
+        """
+        if hasattr(headers_source, "headers"):
+            headers = getattr(headers_source, "headers", None)
+        else:
+            headers = headers_source  # already a headers mapping
+        retry_after = None
+        try:
+            if headers is not None:
+                retry_after = headers.get("Retry-After")
+        except Exception:
+            retry_after = None
+        if retry_after:
+            try:
+                return min(float(retry_after), 30.0)
+            except (TypeError, ValueError):
+                pass
+        return 1.5 * (attempt + 1)
+
+
+def post_reply_back(result: dict, sender: "WebhookSender", *, meeting_title: str | None = None,
+                     board_url: str | None = None, max_items: int = DEFAULT_MAX_ITEMS) -> dict:
+    """Build the Adaptive Card for `result` and send it via `sender`. Never raises."""
+    cap = _clamp_max_items(max_items)
+    try:
+        created, _ = _normalize_result(result)
+    except Exception:
+        created = []
+    item_count = len(created)
+    truncated = item_count > cap
+
+    try:
+        card = build_adaptive_card(result, meeting_title=meeting_title, board_url=board_url, max_items=cap)
+    except Exception:
+        card = _minimal_card(_clean_text(meeting_title, "") or _DEFAULT_HEADER)
+
+    try:
+        send_result = sender.send(card)
+        if not isinstance(send_result, dict):
+            send_result = {"sent": False, "status": None, "error": "sender returned a non-dict result"}
+    except Exception as e:
+        send_result = {"sent": False, "status": None, "error": f"sender raised: {e}"}
+
+    return {
+        "sent": bool(send_result.get("sent")),
+        "status": send_result.get("status"),
+        "error": send_result.get("error"),
+        "item_count": item_count,
+        "truncated": truncated,
+    }

--- a/agent/spine.py
+++ b/agent/spine.py
@@ -1,0 +1,199 @@
+"""
+Preppie spine - transcript -> Azure AI Foundry agent (Responses API) -> triaged Azure DevOps
+backlog, with dedupe.
+
+This is the meeting-to-backlog core (#27 + #62): the agent reasons over the transcript and drives
+the deployed backend tools. Tool-calling is a thin, stateless loop - no separate long-running
+middleware. Both the LLM client and the backend are injected, so the loop is unit-testable without
+network access (see tests/test_spine.py).
+"""
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+import urllib.error
+from typing import Any, Callable
+
+
+# ---------- transcript parsing ----------
+def parse_vtt(text: str) -> str:
+    """Flatten a WEBVTT transcript to 'Speaker: text' lines (drops cue numbers/timestamps)."""
+    lines = []
+    for raw in text.splitlines():
+        s = raw.strip()
+        if not s or s == "WEBVTT" or "-->" in s or s.isdigit():
+            continue
+        head, sep, tail = s.replace("<v ", "").partition(">")
+        if sep:  # had a <v Name> voice tag
+            lines.append(f"{head.strip()}: {tail.strip()}")
+        else:
+            lines.append(s)
+    return "\n".join(lines)
+
+
+def read_transcript(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    return parse_vtt(text) if path.lower().endswith(".vtt") else text
+
+
+# ---------- backend tool dispatch ----------
+class Backend:
+    """Calls the deployed Azure Functions backend. Every call is scoped to one project."""
+
+    def __init__(self, base_url: str, project: str, opener: Callable | None = None,
+                 attempts: int = 4):
+        self.base_url = base_url.rstrip("/")
+        self.project = project
+        self._opener = opener or urllib.request.urlopen
+        self._attempts = attempts
+
+    def _request(self, path: str, method: str, body: dict | None) -> dict:
+        # Retry transient connection blips and 5xx (Flex Consumption cold-scale can drop a
+        # connection); a single hiccup must not abort a whole meeting's backlog.
+        data = json.dumps(body).encode() if body is not None else None
+        for attempt in range(self._attempts):
+            req = urllib.request.Request(
+                f"{self.base_url}{path}", data=data, method=method,
+                headers={"Content-Type": "application/json"})
+            try:
+                with self._opener(req, timeout=45) as r:
+                    return json.loads(r.read().decode())
+            except urllib.error.HTTPError as e:
+                if e.code >= 500 and attempt < self._attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                return {"success": False, "error": f"HTTP {e.code}: {e.read().decode()[:300]}"}
+            except urllib.error.URLError as e:
+                if attempt < self._attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                return {"success": False, "error": f"connection error after {self._attempts} tries: {e}"}
+        return {"success": False, "error": "no request attempts made (attempts must be >= 1)"}
+
+    def dispatch(self, name: str, args: dict) -> dict:
+        """Route a tool call to the backend, injecting the project. Returns the backend JSON."""
+        if name == "read_projects":
+            return self._request("/api/read_projects", "GET", None)
+        if name == "search_work_items":
+            return self._request("/api/search_work_items", "POST", {**args, "project": self.project})
+        if name == "create_work_item":
+            return self._request("/api/create_work_item", "POST", {**args, "project": self.project})
+        if name == "link_work_items":
+            return self._request("/api/link_work_items", "POST", {**args, "project": self.project})
+        return {"success": False, "error": f"unknown tool {name}"}
+
+
+# ---------- tool schemas (match the deployed backend contract) ----------
+TOOLS: list[dict[str, Any]] = [
+    {"type": "function", "name": "read_projects",
+     "description": "List Azure DevOps projects in the org. Use to confirm the target project exists.",
+     "parameters": {"type": "object", "properties": {}, "required": []}},
+    {"type": "function", "name": "search_work_items",
+     "description": "Search existing work items in the target project. Use for DEDUPE before creating "
+                    "(titleContains), and to find a just-created parent.",
+     "parameters": {"type": "object", "properties": {
+         "titleContains": {"type": "string", "description": "Substring to match in the title."},
+         "workItemType": {"type": "string", "description": "Filter by type e.g. Task, Bug, Issue, Epic, Feature, User Story."},
+         "state": {"type": "string"},
+         "tags": {"type": "string", "description": "Substring to match in the item's tags (e.g. 'Risk')."},
+         "top": {"type": "integer"}}, "required": []}},
+    {"type": "function", "name": "create_work_item",
+     "description": "Create one work item in the target project. Returns its id and url. "
+                    "Apply the type->ADO mapping and tags from your instructions.",
+     "parameters": {"type": "object", "properties": {
+         "type": {"type": "string", "description": "Azure DevOps type: Task, Bug, Issue, Epic, Feature, or User Story."},
+         "title": {"type": "string", "description": "Clean, client-safe title (no type prefix)."},
+         "description": {"type": "string", "description": "Rich description: context, who raised it, definition of done."},
+         "acceptanceCriteria": {"type": "array", "items": {"type": "string"},
+                                 "description": "User Stories only. AMP form (Acceptance/Measure/Proof)."},
+         "tags": {"type": "array", "items": {"type": "string"},
+                  "description": "Triage tag when the native type differs, e.g. ['Enhancement'], ['Risk'], ['Question']."},
+         "priority": {"type": "integer", "description": "1 (highest) to 4."},
+         "estimatedEffort": {"type": "string", "description": "Optional effort/size estimate, e.g. '3', '5', '8'."}},
+         "required": ["type", "title", "description"]}},
+    {"type": "function", "name": "link_work_items",
+     "description": "Link a parent to child work items (parent-child hierarchy). "
+                    "sourceId = parent id, targetIds = child ids.",
+     "parameters": {"type": "object", "properties": {
+         "sourceId": {"type": "integer", "description": "Parent work item id."},
+         "targetIds": {"type": "array", "items": {"type": "integer"}, "description": "Child work item ids."},
+         "linkType": {"type": "string", "description": "Default System.LinkTypes.Hierarchy-Forward (parent->child)."}},
+         "required": ["sourceId", "targetIds"]}},
+]
+
+USER_PROMPT = (
+    "Process this meeting transcript into the backlog now. Dedupe before creating, build the "
+    "Epic/Feature/User Story structure, attach captured items under the nearest relevant parent, "
+    "and finish with the reply-back roll-up table.\n\n=== TRANSCRIPT ===\n"
+)
+
+
+def run_spine(transcript: str, instructions: str, client, backend: Backend, model: str,
+              *, on_event: Callable[[str], None] | None = None, max_turns: int = 30) -> dict:
+    """
+    Drive the Responses-API tool loop until the model stops calling tools.
+
+    `client` must expose `responses.create(...)` (an openai AzureOpenAI, or a fake in tests).
+    Returns {created: [...backend results...], reply_back: str, turns: int}.
+    """
+    def emit(msg: str) -> None:
+        if on_event:
+            on_event(msg)
+
+    resp = client.responses.create(
+        model=model, instructions=instructions,
+        input=[{"role": "user", "content": USER_PROMPT + transcript}], tools=TOOLS)
+
+    created: list[dict] = []
+    truncated = False
+    turns = 0
+    for turns in range(1, max_turns + 1):
+        calls = [o for o in resp.output if getattr(o, "type", None) == "function_call"]
+        if not calls:
+            break
+        outputs = []
+        for c in calls:
+            try:
+                args = json.loads(c.arguments or "{}")
+                if not isinstance(args, dict):
+                    raise ValueError(f"expected a JSON object, got {type(args).__name__}")
+            except (json.JSONDecodeError, ValueError) as e:
+                # A malformed tool call must not kill the whole run (and every call_id still
+                # needs a matching output, or the next Responses API call is invalid) - report
+                # it back to the model as a failed call and move on.
+                result = {"success": False, "error": f"malformed arguments for {c.name}: {e}"}
+                emit(f"BAD ARGS for {c.name}: {c.arguments!r} ({e})")
+                outputs.append({"type": "function_call_output", "call_id": c.call_id,
+                                 "output": json.dumps(result)})
+                continue
+            result = backend.dispatch(c.name, args)
+            if c.name == "create_work_item" and result.get("success"):
+                created.append(result)
+                emit(f"create {result['work_item_type']} #{result['work_item_id']}: {result['title']}")
+            elif c.name == "create_work_item":
+                emit(f"CREATE FAILED: {result.get('error')}")
+            elif c.name == "search_work_items":
+                emit(f"dedupe '{args.get('titleContains', '')}' -> {result.get('count', '?')} match(es)")
+            elif c.name == "link_work_items":
+                emit(f"link parent {args.get('sourceId')} -> {args.get('targetIds')}")
+            outputs.append({"type": "function_call_output", "call_id": c.call_id, "output": json.dumps(result)})
+        resp = client.responses.create(
+            model=model, instructions=instructions,
+            previous_response_id=resp.id, input=outputs, tools=TOOLS)
+    else:
+        # The for-loop ran out of turns without ever hitting the `break` above, i.e. the model
+        # was still calling tools when the budget ran out. The last resp we just got back may
+        # itself carry unserviced function_calls and therefore no real reply_back text - don't
+        # let that surface as a silent blank summary when items may already have been created.
+        pending = [o for o in resp.output if getattr(o, "type", None) == "function_call"]
+        if pending:
+            truncated = True
+            emit(f"max_turns ({max_turns}) reached with {len(pending)} pending tool call(s); stopping")
+
+    reply_back = resp.output_text
+    if truncated and not reply_back:
+        reply_back = (f"[Preppie stopped after {max_turns} turns without a final reply - "
+                       f"{len(created)} item(s) were created; check Azure DevOps directly.]")
+    return {"created": created, "reply_back": reply_back, "turns": turns}

--- a/agent/tests/fixtures/sample-meeting.vtt
+++ b/agent/tests/fixtures/sample-meeting.vtt
@@ -1,0 +1,40 @@
+WEBVTT
+
+00:00:01.000 --> 00:00:08.200
+<v Priya Sharma>Okay, thanks for jumping on. The main thing I want to lock down today is the customer self-service portal for Q3. It's a big one — I'd call it our flagship initiative for the quarter.
+
+00:00:08.500 --> 00:00:15.000
+<v Daniel Okoro>Agreed. So at a high level the portal is the umbrella, and under it we've got at least the account management piece and the billing view. Those feel like two separate features to me.
+
+00:00:15.400 --> 00:00:24.800
+<v Priya Sharma>Right. For account management, the concrete thing customers keep asking for is: as a signed-in user I want to update my own contact details without raising a support ticket. That's a clear user story.
+
+00:00:25.100 --> 00:00:31.600
+<v Daniel Okoro>Makes sense. Given a logged-in user, when they change their email, then we send a confirmation link before it takes effect — otherwise we'll get account takeover complaints.
+
+00:00:32.000 --> 00:00:40.300
+<v Priya Sharma>Good, add that as the acceptance criteria. Now, separate thing — we already have a bug in the current portal. The session times out after about two minutes and dumps people back to login. It's been reported by three enterprise customers.
+
+00:00:40.700 --> 00:00:47.100
+<v Daniel Okoro>Yeah I've seen that one. It's the token refresh not firing. That's definitely a bug, not new work — we should log it and prioritise it high.
+
+00:00:47.500 --> 00:00:56.900
+<v Priya Sharma>One risk I want on the record: the billing view depends on the third-party invoicing API, and their rate limits are pretty aggressive. If we design the dashboard to call it live per page load, we could get throttled in production.
+
+00:00:57.300 --> 00:01:04.200
+<v Daniel Okoro>That's a real risk. We might need a caching layer. Actually — would it be worth caching invoices for, say, fifteen minutes? That'd cut the calls dramatically.
+
+00:01:04.600 --> 00:01:12.500
+<v Priya Sharma>That's a nice enhancement on top of the billing feature — let's capture it as an improvement rather than baking it into the core story for now.
+
+00:01:12.900 --> 00:01:21.400
+<v Daniel Okoro>One thing I'm genuinely unsure about: when we say "customers can manage their account", does that include deleting the account entirely? Because GDPR erasure is a whole separate workflow with legal sign-off.
+
+00:01:21.800 --> 00:01:29.000
+<v Priya Sharma>Good question — I don't have the answer. Let's flag that as an open question for legal before we scope the deletion flow. Don't guess at it.
+
+00:01:29.400 --> 00:01:36.700
+<v Daniel Okoro>Perfect. And a small task on my side — I'll set up the feature branch and the CI pipeline for the portal repo so we're ready to build. Nothing fancy, just the plumbing.
+
+00:01:37.000 --> 00:01:42.300
+<v Priya Sharma>Great. I think that's a solid backlog. Let's get it written up properly and we'll review it at standup tomorrow.

--- a/agent/tests/test_reply_back.py
+++ b/agent/tests/test_reply_back.py
@@ -1,0 +1,613 @@
+"""Unit tests for agent.reply_back. No network: the HTTP opener and the sender are injected."""
+import json
+import urllib.error
+
+import pytest
+
+from agent.reply_back import (
+    DEFAULT_MAX_ITEMS,
+    WebhookSender,
+    build_adaptive_card,
+    post_reply_back,
+)
+
+
+# ---------- shared fakes ----------
+class _FakeResp:
+    """Mirrors agent.tests.test_spine._FakeResp: a urlopen-context-manager stand-in."""
+
+    def __init__(self, body=b"", status=200):
+        self._b = body if isinstance(body, bytes) else json.dumps(body).encode()
+        self.status = status
+        self.code = status
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def _http_error(code, body=b"", headers=None):
+    return urllib.error.HTTPError(
+        url="https://example.invalid/webhook", code=code, msg=f"HTTP {code}",
+        hdrs=headers or {}, fp=None if body == b"" else __import__("io").BytesIO(body))
+
+
+def _sample_result():
+    return {
+        "created": [
+            {"work_item_type": "Epic", "work_item_id": 1, "title": "Portal", "url": "http://x/1"},
+            {"work_item_type": "Feature", "work_item_id": 2, "title": "Auth", "url": "http://x/2"},
+            {"work_item_type": "Feature", "work_item_id": 3, "title": "Billing", "url": "http://x/3"},
+            {"work_item_type": "Bug", "work_item_id": 4, "title": "Crash on save", "url": "http://x/4"},
+        ],
+        "reply_back": "Logged 4 items.",
+        "turns": 3,
+    }
+
+
+# =========================================================================
+# build_adaptive_card
+# =========================================================================
+def test_card_has_valid_adaptive_card_envelope():
+    card = build_adaptive_card(_sample_result())
+    assert card["$schema"] == "http://adaptivecards.io/schemas/adaptive-card.json"
+    assert card["type"] == "AdaptiveCard"
+    assert card["version"] == "1.4"
+    assert isinstance(card["body"], list) and len(card["body"]) > 0
+
+
+def test_card_default_header_text():
+    card = build_adaptive_card(_sample_result())
+    assert card["body"][0]["text"] == "\U0001F5C2️ Preppie — meeting backlog"
+    assert card["body"][0]["wrap"] is True
+
+
+def test_card_custom_meeting_title_overrides_header():
+    card = build_adaptive_card(_sample_result(), meeting_title="Sprint 12 Planning")
+    assert card["body"][0]["text"] == "Sprint 12 Planning"
+
+
+def test_card_summary_line_breakdown_by_type_in_first_seen_order():
+    card = build_adaptive_card(_sample_result())
+    summary = card["body"][1]["text"]
+    assert summary == "4 work item(s) created: 1 Epic · 2 Features · 1 Bug"
+
+
+def test_card_body_lines_use_adaptive_card_markdown_with_link():
+    card = build_adaptive_card(_sample_result())
+    texts = [b["text"] for b in card["body"]]
+    assert "- **Epic #1** [Portal](http://x/1)" in texts
+    assert "- **Bug #4** [Crash on save](http://x/4)" in texts
+
+
+def test_card_missing_url_renders_title_without_link():
+    result = {"created": [{"work_item_type": "Task", "work_item_id": 9, "title": "No link"}],
+              "reply_back": ""}
+    card = build_adaptive_card(result)
+    texts = [b["text"] for b in card["body"]]
+    assert "- **Task #9** No link" in texts
+
+
+def test_card_missing_title_falls_back_to_untitled():
+    result = {"created": [{"work_item_type": "Task", "work_item_id": 9, "url": "http://x"}]}
+    card = build_adaptive_card(result)
+    texts = [b["text"] for b in card["body"]]
+    assert "- **Task #9** [(untitled)](http://x)" in texts
+
+
+def test_card_missing_type_and_id_use_fallbacks():
+    result = {"created": [{"title": "Mystery item"}]}
+    card = build_adaptive_card(result)
+    texts = [b["text"] for b in card["body"]]
+    assert "- **Item #?** Mystery item" in texts
+
+
+def test_card_reply_back_appended_as_wrapped_text_block():
+    card = build_adaptive_card(_sample_result())
+    assert any(b["text"] == "Logged 4 items." and b.get("wrap") is True for b in card["body"])
+
+
+def test_card_empty_reply_back_adds_no_extra_block():
+    result = {"created": [], "reply_back": ""}
+    card = build_adaptive_card(result)
+    assert not any(b["text"] == "" for b in card["body"])
+
+
+def test_card_none_reply_back_is_safe():
+    result = {"created": [], "reply_back": None}
+    card = build_adaptive_card(result)
+    assert card["body"][1]["text"] == "No backlog items were created from this meeting."
+
+
+def test_card_open_board_action_present_when_board_url_given():
+    card = build_adaptive_card(_sample_result(), board_url="https://dev.azure.com/org/proj/_boards")
+    assert card["actions"] == [{"type": "Action.OpenUrl", "title": "Open board",
+                                "url": "https://dev.azure.com/org/proj/_boards"}]
+
+
+def test_card_no_actions_key_when_board_url_absent():
+    card = build_adaptive_card(_sample_result())
+    assert "actions" not in card
+
+
+# ---- empty created ----
+def test_card_empty_created_still_valid_and_has_no_items_message():
+    card = build_adaptive_card({"created": [], "reply_back": ""})
+    assert card["type"] == "AdaptiveCard"
+    assert card["body"][1]["text"] == "No backlog items were created from this meeting."
+
+
+def test_card_empty_created_with_reply_back_still_appends_it():
+    card = build_adaptive_card({"created": [], "reply_back": "Nothing to log this time."})
+    texts = [b["text"] for b in card["body"]]
+    assert "No backlog items were created from this meeting." in texts
+    assert "Nothing to log this time." in texts
+
+
+# ---- truncation ----
+def test_card_truncates_over_max_items_and_notes_extra_count():
+    created = [{"work_item_type": "Task", "work_item_id": i, "title": f"T{i}", "url": f"http://x/{i}"}
+               for i in range(25)]
+    card = build_adaptive_card({"created": created, "reply_back": ""}, max_items=20)
+    item_lines = [b["text"] for b in card["body"] if b["text"].startswith("- **Task")]
+    assert len(item_lines) == 20
+    more_line = card["body"][-1]["text"] if not card["body"][-1]["text"].startswith("- **Task") else None
+    assert any("+5 more" in b["text"] for b in card["body"])
+
+
+def test_card_truncation_links_board_url_when_given():
+    created = [{"work_item_type": "Task", "work_item_id": i, "title": f"T{i}"} for i in range(21)]
+    card = build_adaptive_card({"created": created}, max_items=20, board_url="https://board.example")
+    assert any(b["text"] == "[+1 more — see the full board](https://board.example)"
+              for b in card["body"])
+
+
+def test_card_truncation_without_board_url_is_plain_text():
+    created = [{"work_item_type": "Task", "work_item_id": i, "title": f"T{i}"} for i in range(21)]
+    card = build_adaptive_card({"created": created}, max_items=20)
+    assert any(b["text"] == "+1 more — see the full board" for b in card["body"])
+
+
+def test_card_at_exactly_max_items_is_not_truncated():
+    created = [{"work_item_type": "Task", "work_item_id": i, "title": f"T{i}"} for i in range(20)]
+    card = build_adaptive_card({"created": created}, max_items=20)
+    assert not any("more" in b["text"] and "see the full board" in b["text"] for b in card["body"])
+
+
+# ---- markdown / JSON safety ----
+def test_card_title_with_markdown_metachars_stays_json_safe():
+    nasty_title = 'Fix "the" [bracket] (paren) *star* _under_ `tick` <tag> | pipe\nnewline'
+    result = {"created": [{"work_item_type": "Bug", "work_item_id": 5, "title": nasty_title,
+                          "url": "http://x"}]}
+    card = build_adaptive_card(result)
+    # Must round-trip through json.dumps/loads without error, and the title survives (minus
+    # embedded newlines, which are flattened to spaces to keep each bullet on one line).
+    encoded = json.dumps(card)
+    decoded = json.loads(encoded)
+    assert decoded == card
+    line = [b["text"] for b in card["body"] if b["text"].startswith("- **Bug #5**")][0]
+    assert "\n" not in line
+    assert "bracket" in line and "pipe" in line and "newline" in line
+
+
+def test_card_reply_back_with_metachars_stays_json_safe():
+    nasty = 'Summary: <b>bold</b> & "quotes" & [brackets] & `code`\nsecond line'
+    card = build_adaptive_card({"created": [], "reply_back": nasty})
+    json.dumps(card)  # must not raise
+    assert any("quotes" in b["text"] for b in card["body"])
+
+
+# ---- never raises ----
+def test_card_never_raises_on_none_result():
+    card = build_adaptive_card(None)
+    assert card["type"] == "AdaptiveCard" and card["version"] == "1.4"
+
+
+def test_card_never_raises_on_empty_dict_result():
+    card = build_adaptive_card({})
+    assert card["type"] == "AdaptiveCard"
+    assert card["body"][1]["text"] == "No backlog items were created from this meeting."
+
+
+def test_card_never_raises_on_completely_malformed_result():
+    card = build_adaptive_card({"created": "not-a-list", "reply_back": 12345})
+    assert card["type"] == "AdaptiveCard"
+
+
+def test_card_never_raises_on_created_items_that_are_not_dicts():
+    card = build_adaptive_card({"created": [None, "oops", 42, {"title": "ok one"}]})
+    assert card["type"] == "AdaptiveCard"
+    texts = [b["text"] for b in card["body"]]
+    assert any("ok one" in t for t in texts)
+
+
+# =========================================================================
+# WebhookSender.send
+# =========================================================================
+def test_sender_no_url_configured_returns_error_without_request(monkeypatch):
+    called = {"n": 0}
+
+    def opener(req, timeout=None):
+        called["n"] += 1
+        return _FakeResp(status=202)
+
+    for bad_url in (None, "", "   "):
+        sender = WebhookSender(bad_url, opener=opener)
+        out = sender.send({"type": "AdaptiveCard"})
+        assert out == {"sent": False, "status": None, "error": "no webhook url configured"}
+    assert called["n"] == 0
+
+
+def test_sender_success_on_202_workflows(monkeypatch):
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda *_: None)
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["content_type"] = req.get_header("Content-type")
+        seen["body"] = json.loads(req.data.decode())
+        return _FakeResp(status=202)
+
+    sender = WebhookSender("https://example.invalid/webhook", opener=opener)
+    out = sender.send({"type": "AdaptiveCard", "body": []})
+
+    assert out == {"sent": True, "status": 202, "error": None}
+    assert seen["url"] == "https://example.invalid/webhook"
+    assert seen["method"] == "POST"
+    assert seen["content_type"] == "application/json"
+    assert seen["body"]["type"] == "message"
+    assert seen["body"]["attachments"][0]["contentType"] == "application/vnd.microsoft.card.adaptive"
+    assert seen["body"]["attachments"][0]["content"] == {"type": "AdaptiveCard", "body": []}
+
+
+def test_sender_success_on_200_legacy_connector_body_1(monkeypatch):
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda *_: None)
+
+    def opener(req, timeout=None):
+        return _FakeResp(body=b"1", status=200)
+
+    out = WebhookSender("https://example.invalid/webhook", opener=opener).send({"type": "AdaptiveCard"})
+    assert out == {"sent": True, "status": 200, "error": None}
+
+
+def test_sender_retries_then_succeeds_on_5xx(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda s: sleeps.append(s))
+    calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise _http_error(503)
+        return _FakeResp(status=202)
+
+    out = WebhookSender("https://x", opener=opener, attempts=4).send({})
+    assert out == {"sent": True, "status": 202, "error": None}
+    assert calls["n"] == 3
+    assert len(sleeps) == 2  # backed off twice before succeeding
+
+
+def test_sender_retries_then_succeeds_on_urlerror(monkeypatch):
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda *_: None)
+    calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise urllib.error.URLError("connection refused")
+        return _FakeResp(status=202)
+
+    out = WebhookSender("https://x", opener=opener, attempts=4).send({})
+    assert out == {"sent": True, "status": 202, "error": None}
+    assert calls["n"] == 2
+
+
+def test_sender_429_respects_retry_after_header_then_succeeds(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda s: sleeps.append(s))
+    calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _http_error(429, headers={"Retry-After": "5"})
+        return _FakeResp(status=202)
+
+    out = WebhookSender("https://x", opener=opener, attempts=3).send({})
+    assert out == {"sent": True, "status": 202, "error": None}
+    assert sleeps == [5.0]
+
+
+def test_sender_429_retry_after_capped_at_30_seconds(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda s: sleeps.append(s))
+    calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _http_error(429, headers={"Retry-After": "120"})
+        return _FakeResp(status=202)
+
+    WebhookSender("https://x", opener=opener, attempts=3).send({})
+    assert sleeps == [30.0]
+
+
+def test_sender_429_without_retry_after_uses_default_backoff(monkeypatch):
+    sleeps = []
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda s: sleeps.append(s))
+    calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise _http_error(429)
+        return _FakeResp(status=202)
+
+    out = WebhookSender("https://x", opener=opener, attempts=3).send({})
+    assert out["sent"] is True
+    assert sleeps == [1.5]
+
+
+def test_sender_gives_up_after_attempts_exhausted(monkeypatch):
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda *_: None)
+
+    def always_503(req, timeout=None):
+        raise _http_error(503)
+
+    out = WebhookSender("https://x", opener=always_503, attempts=3).send({})
+    assert out["sent"] is False
+    assert out["status"] == 503
+    assert "HTTP 503" in out["error"]
+
+
+def test_sender_gives_up_after_attempts_exhausted_urlerror(monkeypatch):
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda *_: None)
+
+    def always_refuse(req, timeout=None):
+        raise urllib.error.URLError("refused")
+
+    out = WebhookSender("https://x", opener=always_refuse, attempts=3).send({})
+    assert out == {"sent": False, "status": None,
+                   "error": "connection error after 3 tries: <urlopen error refused>"}
+
+
+def test_sender_non_retryable_4xx_fails_without_burning_all_attempts(monkeypatch):
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda *_: None)
+    calls = {"n": 0}
+
+    def opener(req, timeout=None):
+        calls["n"] += 1
+        raise _http_error(400, body=b"bad card schema")
+
+    out = WebhookSender("https://x", opener=opener, attempts=4).send({})
+    assert out == {"sent": False, "status": 400, "error": "HTTP 400: bad card schema"}
+    assert calls["n"] == 1  # no retries burned on a non-retryable 4xx
+
+
+def test_sender_never_raises_on_unexpected_opener_exception(monkeypatch):
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda *_: None)
+
+    def boom(req, timeout=None):
+        raise ValueError("opener exploded")
+
+    out = WebhookSender("https://x", opener=boom, attempts=2).send({})
+    assert out["sent"] is False
+    assert "unexpected error" in out["error"]
+
+
+# =========================================================================
+# post_reply_back
+# =========================================================================
+class _FakeSender:
+    def __init__(self, response):
+        self._response = response
+        self.sent_cards = []
+
+    def send(self, card):
+        self.sent_cards.append(card)
+        return self._response
+
+
+def test_post_reply_back_success_reports_item_count_and_not_truncated():
+    sender = _FakeSender({"sent": True, "status": 202, "error": None})
+    out = post_reply_back(_sample_result(), sender)
+    assert out == {"sent": True, "status": 202, "error": None, "item_count": 4, "truncated": False}
+    assert sender.sent_cards[0]["type"] == "AdaptiveCard"
+
+
+def test_post_reply_back_failure_propagates_error():
+    sender = _FakeSender({"sent": False, "status": None, "error": "no webhook url configured"})
+    out = post_reply_back({"created": [], "reply_back": ""}, sender)
+    assert out == {"sent": False, "status": None, "error": "no webhook url configured",
+                   "item_count": 0, "truncated": False}
+
+
+def test_post_reply_back_reports_truncated_when_over_max_items():
+    created = [{"work_item_type": "Task", "work_item_id": i, "title": f"T{i}"} for i in range(23)]
+    sender = _FakeSender({"sent": True, "status": 202, "error": None})
+    out = post_reply_back({"created": created, "reply_back": ""}, sender, max_items=20)
+    assert out["item_count"] == 23
+    assert out["truncated"] is True
+    assert out["truncated"] is True and DEFAULT_MAX_ITEMS == 20
+
+
+def test_post_reply_back_never_raises_on_none_result():
+    sender = _FakeSender({"sent": True, "status": 202, "error": None})
+    out = post_reply_back(None, sender)
+    assert out["sent"] is True and out["item_count"] == 0 and out["truncated"] is False
+
+
+def test_post_reply_back_never_raises_when_sender_raises():
+    class _ExplodingSender:
+        def send(self, card):
+            raise RuntimeError("network is on fire")
+
+    out = post_reply_back(_sample_result(), _ExplodingSender())
+    assert out["sent"] is False
+    assert "network is on fire" in out["error"]
+    assert out["item_count"] == 4
+
+
+def test_post_reply_back_handles_sender_returning_non_dict():
+    class _WeirdSender:
+        def send(self, card):
+            return None
+
+    out = post_reply_back({"created": []}, _WeirdSender())
+    assert out["sent"] is False
+    assert out["error"] == "sender returned a non-dict result"
+
+
+# ---- end-to-end: post_reply_back with a real WebhookSender + fake opener ----
+def test_post_reply_back_end_to_end_with_fake_opener(monkeypatch):
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda *_: None)
+    posted = {}
+
+    def opener(req, timeout=None):
+        posted["envelope"] = json.loads(req.data.decode())
+        return _FakeResp(status=202)
+
+    sender = WebhookSender("https://example.invalid/webhook", opener=opener)
+    out = post_reply_back(_sample_result(), sender, board_url="https://board.example")
+
+    assert out["sent"] is True and out["status"] == 202 and out["item_count"] == 4
+    content = posted["envelope"]["attachments"][0]["content"]
+    assert content["type"] == "AdaptiveCard"
+    assert content["actions"][0]["url"] == "https://board.example"
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-q"]))
+
+
+# =========================================================================
+# adversarial-review regressions (production-hardening)
+# =========================================================================
+def test_card_stays_under_28kb_with_huge_reply_back_and_title():
+    # spine sets reply_back from raw LLM output (uncapped); a verbose reply or a pathological
+    # title must never blow the ~28KB Teams cap and sink the whole post. The size guard caps
+    # fields and hard-trims the body, but the created-item count (summary) must always survive.
+    result = {
+        "created": [{"work_item_type": "Bug", "work_item_id": 5,
+                     "title": "T" * 40000, "url": "http://x/5"}],
+        "reply_back": "x" * 40000,
+    }
+    card = build_adaptive_card(result)
+    assert len(json.dumps(card).encode()) < 28000
+    assert any("1 work item(s) created" in b.get("text", "") for b in card["body"])
+
+
+def test_card_many_long_items_hard_trims_to_fit_and_keeps_summary():
+    result = {"created": [{"work_item_type": "Task", "work_item_id": i,
+                           "title": "long title " * 40, "url": "http://x/%d" % i}
+                          for i in range(500)],
+              "reply_back": ""}
+    card = build_adaptive_card(result, max_items=500)
+    assert len(json.dumps(card).encode()) < 28000
+    assert any("work item(s) created" in b.get("text", "") for b in card["body"])
+
+
+def test_item_url_with_space_is_percent_encoded_so_link_survives():
+    result = {"created": [{"work_item_type": "Task", "work_item_id": 3,
+                           "title": "Normal", "url": "http://x/3?a=b c&d=1"}]}
+    card = build_adaptive_card(result)
+    line = [b["text"] for b in card["body"] if b["text"].startswith("- **Task #3**")][0]
+    assert "%20" in line          # the space was encoded
+    assert " c&d" not in line     # no raw space left inside the (...) link
+    assert line.endswith(")")
+
+
+def test_title_with_unbalanced_bracket_is_escaped():
+    result = {"created": [{"work_item_type": "Task", "work_item_id": 5,
+                           "title": "Weird ] title", "url": "http://x/5"}]}
+    card = build_adaptive_card(result)
+    line = [b["text"] for b in card["body"] if b["text"].startswith("- **Task #5**")][0]
+    assert line == r"- **Task #5** [Weird \] title](http://x/5)"
+
+
+def test_title_with_embedded_link_cannot_hijack_the_real_url():
+    # A transcript-derived title containing its own [text](url) must not become the clickable
+    # target - the real work-item url has to win.
+    result = {"created": [{"work_item_type": "Bug", "work_item_id": 2,
+                           "title": "See [details](http://evil.example/phish)",
+                           "url": "http://x/2"}]}
+    card = build_adaptive_card(result)
+    line = [b["text"] for b in card["body"] if b["text"].startswith("- **Bug #2**")][0]
+    assert r"\[details\]" in line          # embedded brackets escaped -> inert
+    assert line.endswith("](http://x/2)")  # the real url is the link target
+
+
+def test_card_max_items_true_does_not_silently_cap_to_one():
+    # bool is an int subclass; max_items=True must not be read as max_items=1.
+    result = {"created": [{"work_item_type": "Task", "work_item_id": i, "title": "t%d" % i,
+                           "url": "http://x/%d" % i} for i in range(5)], "reply_back": ""}
+    card = build_adaptive_card(result, max_items=True)
+    item_lines = [b["text"] for b in card["body"] if b["text"].startswith("- **Task")]
+    assert len(item_lines) == 5
+
+
+class _FakeRespWithHeaders(_FakeResp):
+    def __init__(self, body=b"", status=200, headers=None):
+        super().__init__(body, status)
+        self.headers = headers or {}
+
+
+def test_sender_direct_response_429_honors_retry_after(monkeypatch):
+    # A custom injected opener that RETURNS a 429 response object (rather than raising HTTPError)
+    # must still honor Retry-After, identically to the HTTPError path.
+    sleeps = []
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda s: sleeps.append(s))
+    seq = [_FakeRespWithHeaders(status=429, headers={"Retry-After": "7"}),
+           _FakeRespWithHeaders(b"1", status=200)]
+
+    def opener(req, timeout=None):
+        return seq.pop(0)
+
+    out = WebhookSender("https://x", opener=opener, attempts=3).send({})
+    assert out["sent"] is True
+    assert sleeps == [7.0]
+
+
+def test_sender_direct_response_3xx_is_treated_as_failure(monkeypatch):
+    monkeypatch.setattr("agent.reply_back.time.sleep", lambda *_: None)
+
+    def opener(req, timeout=None):
+        return _FakeResp(b"", status=300)
+
+    out = WebhookSender("https://x", opener=opener, attempts=3).send({})
+    assert out["sent"] is False and out["status"] == 300
+
+
+def test_sender_attempts_zero_returns_clean_failure_without_request():
+    called = {"n": 0}
+
+    def opener(req, timeout=None):
+        called["n"] += 1
+        return _FakeResp(b"1", status=200)
+
+    out = WebhookSender("https://x", opener=opener, attempts=0).send({})
+    assert out["sent"] is False
+    assert called["n"] == 0  # no request attempted
+
+
+def test_post_reply_back_handles_non_dict_int_and_list_sender_results():
+    class _IntSender:
+        def send(self, card):
+            return 7
+
+    class _ListSender:
+        def send(self, card):
+            return ["nope"]
+
+    for sender in (_IntSender(), _ListSender()):
+        out = post_reply_back(_sample_result(), sender)
+        assert out["sent"] is False
+        assert out["item_count"] == 4

--- a/agent/tests/test_spine.py
+++ b/agent/tests/test_spine.py
@@ -1,0 +1,236 @@
+"""Unit tests for the Preppie spine. No network: the backend and the LLM client are injected."""
+import json
+import os
+import types
+
+from agent.spine import parse_vtt, read_transcript, Backend, run_spine
+
+
+# ---------- transcript parsing ----------
+def test_parse_vtt_extracts_speakers():
+    vtt = ("WEBVTT\n\n1\n00:00:01.000 --> 00:00:03.000\n<v Alice>Hello there\n\n"
+           "00:00:04.000 --> 00:00:05.000\n<v Bob>Hi Alice\n")
+    assert parse_vtt(vtt) == "Alice: Hello there\nBob: Hi Alice"
+
+
+def test_parse_vtt_keeps_untagged_lines_and_drops_noise():
+    assert parse_vtt("WEBVTT\n\n2\n00:00:01.000 --> 00:00:02.000\nplain line\n") == "plain line"
+
+
+def test_read_transcript_plain_file_is_verbatim(tmp_path):
+    p = tmp_path / "notes.txt"
+    p.write_text("Alice: just do it")
+    assert read_transcript(str(p)) == "Alice: just do it"
+
+
+def test_sample_fixture_parses():
+    fixture = os.path.join(os.path.dirname(__file__), "fixtures", "sample-meeting.vtt")
+    out = read_transcript(fixture)
+    assert "Priya Sharma:" in out and "Daniel Okoro:" in out and "-->" not in out
+
+
+# ---------- backend dispatch ----------
+class _FakeResp:
+    def __init__(self, body):
+        self._b = json.dumps(body).encode()
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_backend_dispatch_injects_project_and_posts():
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["body"] = json.loads(req.data.decode()) if req.data else None
+        return _FakeResp({"success": True, "count": 0})
+
+    Backend("https://backend.example/", "MyProj", opener=opener).dispatch(
+        "search_work_items", {"titleContains": "foo"})
+    assert seen["url"].endswith("/api/search_work_items")
+    assert seen["method"] == "POST"
+    assert seen["body"] == {"project": "MyProj", "titleContains": "foo"}
+
+
+def test_backend_read_projects_is_get_no_body():
+    def opener(req, timeout=None):
+        assert req.get_method() == "GET"
+        assert req.data is None
+        return _FakeResp({"success": True, "projects": []})
+
+    Backend("https://b", "P", opener=opener).dispatch("read_projects", {})
+
+
+def test_backend_retries_transient_connection_error(monkeypatch):
+    import urllib.error
+    monkeypatch.setattr("agent.spine.time.sleep", lambda *_: None)  # no real backoff in tests
+    calls = {"n": 0}
+
+    def flaky_opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise urllib.error.URLError("connection refused")
+        return _FakeResp({"success": True, "count": 0})
+
+    out = Backend("https://b", "P", opener=flaky_opener).dispatch("search_work_items", {})
+    assert out["success"] is True and calls["n"] == 3  # failed twice, succeeded on the third
+
+
+def test_backend_gives_up_after_attempts(monkeypatch):
+    import urllib.error
+    monkeypatch.setattr("agent.spine.time.sleep", lambda *_: None)
+
+    def always_refuse(req, timeout=None):
+        raise urllib.error.URLError("refused")
+
+    out = Backend("https://b", "P", opener=always_refuse, attempts=3).dispatch("read_projects", {})
+    assert out["success"] is False and "connection error" in out["error"]
+
+
+def test_backend_dispatch_project_cannot_be_overridden_by_args():
+    # The backend's guarantee is that every call is scoped to Backend.project. If the model's
+    # tool-call arguments ever contained a stray "project" key, it must not win over that.
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["body"] = json.loads(req.data.decode())
+        return _FakeResp({"success": True})
+
+    Backend("https://b", "RealProject", opener=opener).dispatch(
+        "create_work_item", {"type": "Task", "title": "t", "description": "d", "project": "Hijacked"})
+    assert seen["body"]["project"] == "RealProject"
+
+
+# ---------- the run loop ----------
+def _fcall(name, args, call_id):
+    return types.SimpleNamespace(type="function_call", name=name,
+                                 arguments=json.dumps(args), call_id=call_id)
+
+
+class _FakeClient:
+    """Replays a scripted list of (output_items, output_text) responses."""
+
+    def __init__(self, scripted):
+        self._scripted = list(scripted)
+        self._n = 0
+        self.calls = []
+        self.responses = self
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        out, text = self._scripted[self._n]
+        self._n += 1
+        return types.SimpleNamespace(output=out, output_text=text, id=f"resp_{self._n}")
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.dispatched = []
+        self._next_id = 100
+
+    def dispatch(self, name, args):
+        self.dispatched.append((name, args))
+        if name == "create_work_item":
+            self._next_id += 1
+            return {"success": True, "work_item_id": self._next_id,
+                    "work_item_type": args["type"], "title": args["title"], "url": "http://x"}
+        if name == "search_work_items":
+            return {"success": True, "count": 0, "workItems": []}
+        return {"success": True}
+
+
+def test_run_spine_dedupes_before_create_and_collects_results():
+    scripted = [
+        ([_fcall("search_work_items", {"titleContains": "Portal"}, "c1"),
+          _fcall("create_work_item", {"type": "Epic", "title": "Portal", "description": "d"}, "c2")], ""),
+        ([], "done: logged 1 item"),
+    ]
+    client, backend = _FakeClient(scripted), _FakeBackend()
+    result = run_spine("Alice: build a portal", "INSTR", client, backend, "gpt-x")
+
+    names = [n for n, _ in backend.dispatched]
+    assert names.index("search_work_items") < names.index("create_work_item")  # dedupe first
+    assert len(result["created"]) == 1
+    assert result["created"][0]["title"] == "Portal"
+    assert result["reply_back"] == "done: logged 1 item"
+    # tool outputs were fed back referencing the prior response id
+    assert client.calls[1].get("previous_response_id") == "resp_1"
+
+
+def test_run_spine_terminates_at_max_turns():
+    forever = ([_fcall("search_work_items", {}, "c")], "")
+    result = run_spine("t", "i", _FakeClient([forever] * 50), _FakeBackend(), "m", max_turns=5)
+    assert result["turns"] == 5
+    # the model never produced a final text reply (it kept calling tools) - the caller must still
+    # get a non-blank explanation rather than silently seeing an empty reply-back.
+    assert result["reply_back"] and "5 turns" in result["reply_back"]
+
+
+def test_run_spine_handles_malformed_tool_arguments_without_crashing():
+    scripted = [
+        ([types.SimpleNamespace(type="function_call", name="create_work_item",
+                                arguments="{not valid json", call_id="c1")], ""),
+        ([], "done"),
+    ]
+    client, backend = _FakeClient(scripted), _FakeBackend()
+    result = run_spine("t", "i", client, backend, "m")
+    # the bad call must never reach the backend, but the loop must still feed an output back
+    # (referencing the same call_id) so the model isn't left hanging, and the run completes.
+    assert backend.dispatched == []
+    assert result["reply_back"] == "done"
+    second_call_outputs = client.calls[1]["input"]
+    assert second_call_outputs[0]["call_id"] == "c1"
+    assert json.loads(second_call_outputs[0]["output"])["success"] is False
+
+
+def test_run_spine_handles_non_object_tool_arguments():
+    scripted = [
+        ([types.SimpleNamespace(type="function_call", name="search_work_items",
+                                arguments="[1, 2, 3]", call_id="c1")], ""),
+        ([], "done"),
+    ]
+    result = run_spine("t", "i", _FakeClient(scripted), _FakeBackend(), "m")
+    assert result["reply_back"] == "done"
+
+
+class _FailingCreateBackend:
+    """A backend whose create_work_item always fails, to check the loop doesn't leave the model
+    hanging (every call_id still needs a function_call_output) or lose track of the run."""
+
+    def __init__(self):
+        self.dispatched = []
+
+    def dispatch(self, name, args):
+        self.dispatched.append((name, args))
+        return {"success": False, "error": "Azure DevOps rejected the request"}
+
+
+def test_run_spine_feeds_output_back_after_failed_create():
+    scripted = [
+        ([_fcall("create_work_item", {"type": "Task", "title": "T", "description": "d"}, "c1")], ""),
+        ([], "done: 0 items logged"),
+    ]
+    client = _FakeClient(scripted)
+    result = run_spine("t", "i", client, _FailingCreateBackend(), "m")
+
+    assert result["created"] == []  # nothing to show for a failed create
+    assert result["reply_back"] == "done: 0 items logged"  # the loop still completed normally
+    fed_back = client.calls[1]["input"]
+    assert fed_back[0]["call_id"] == "c1"
+    assert json.loads(fed_back[0]["output"])["success"] is False
+
+
+def test_run_spine_records_events():
+    events = []
+    scripted = [([_fcall("create_work_item", {"type": "Task", "title": "T", "description": "d"}, "c1")], ""),
+                ([], "ok")]
+    run_spine("t", "i", _FakeClient(scripted), _FakeBackend(), "m", on_event=events.append)
+    assert any("create Task" in e for e in events)

--- a/src/function_app.py
+++ b/src/function_app.py
@@ -287,8 +287,11 @@ def create_work_item(req: func.HttpRequest) -> func.HttpResponse:
                 mimetype="application/json"
             )
 
-        # Extract metadata from description if present (speaker, timestamp, meeting ID)
-        tags = []
+        # Tags carry the T-Minus-15 triage type when the process template has no native
+        # work item type for it (e.g. Enhancement -> Task+tag, Risk/Question -> Issue+tag).
+        tags = req_body.get("tags") or []
+        if isinstance(tags, str):
+            tags = [t.strip() for t in tags.split(";") if t.strip()]
         custom_fields = {}
 
         # Get DevOps client and create work item


### PR DESCRIPTION
## Summary

Closes the loop: after a run, Preppie posts a roll-up of what it logged **back into the Teams
channel** as an Adaptive Card — so the people who were in the meeting can see what was captured and
say "that's not right" while it's still fresh.

```
spine (#78) → work items → Adaptive Card → Teams channel
```

If `PREPPIE_TEAMS_WEBHOOK_URL` isn't set, the run behaves exactly as it does today and notes that it
skipped the post. Nothing existing changes.

## Issues Addressed

### Fixes #30 — Teams chat notifications for created work items

## Key decisions (calling these out for review)

1. **Transport: Teams Incoming Webhook (Workflows), not the meeting chat via Graph.** Posting into
   the meeting *chat* needs the bot to be a member of the conversation, which pulls in the
   app-hosted media/bot layer we scoped out. A channel webhook needs no app registration and no
   admin — one URL and it works. `WebhookSender` takes an injectable opener, so swapping to a Graph
   chat transport later is a drop-in.

2. **Adaptive Card, not plain text.** Structured item list with links straight to each work item, so
   correcting something is one click, not a search.

3. **Never raises.** A failed reply-back must not fail a run that has already successfully created
   the backlog. `post_reply_back` returns a result and logs; it doesn't propagate.

4. **Any 2xx is success** — including the legacy webhook that returns `200` with a literal `1` body.

## Key Changes

- `agent/reply_back.py` — `build_adaptive_card(result, *, meeting_title, board_url, max_items)`,
  `WebhookSender(url, opener, attempts)` (retry/backoff, `Retry-After` honoured on both the raised
  `HTTPError` and direct-response paths), `post_reply_back(...)`.
- `agent/cli.py` — posts after a run **if** the webhook is configured; otherwise a skip note.
- `agent/config.py` — `PREPPIE_TEAMS_WEBHOOK_URL`, `PREPPIE_BOARD_URL`.
- `agent/tests/test_reply_back.py` — 54 tests, transport injected (no network).

## Robustness

Review caught one **blocker** worth spelling out: the card is built from LLM output, which is
unbounded, and Teams silently rejects payloads over ~28KB. A long meeting would have produced a card
that **failed to post at all — losing every item**. Fixed with a three-layer size guard:

- `MAX_TITLE_CHARS = 200`, `MAX_REPLY_BACK_CHARS = 3500`
- a hard byte-trim loop to `MAX_CARD_BYTES = 26000` that **always preserves the summary and counts**,
  so the post degrades gracefully instead of vanishing

Also fixed, all from transcript-derived text reaching a markdown renderer:

- URLs percent-encoded — a space or paren in a board URL broke the link
- `[` / `]` escaped in titles — an unbalanced bracket broke the line, and an embedded `[x](url)`
  could hijack the real work-item link
- bool-safe `max_items` / `attempts`

## Known limitations / follow-up

- Markdown **pipe tables render as raw text** in Adaptive Card `TextBlock`s — so the roll-up table
  from the spine's reply-back shows unformatted. The structured item list is the reliable
  representation and is what the card leads with. (Documented behaviour of Adaptive Cards, not a bug
  here; a `ColumnSet` layout would be the fix if the table matters.)
- Channel-level post, not per-meeting-thread — see decision 1.

## Test Plan

- [x] `python -m pytest agent/tests/ -q` → **69 passing**, no network (card build, size guards at
      every layer, markdown escaping, retry/backoff, `Retry-After`, 2xx variants, never-raises).
- [x] Posted live into a real Teams channel from the real-meeting board run (#29–#40) —
      **HTTP 202 Accepted**, 12 items, card rendered as expected.

```bash
python -m pytest agent/tests/ -q
PREPPIE_TEAMS_WEBHOOK_URL="https://..." python -m agent.cli "<join-url-or-vtt>"
```

## Note on branching

Branches off `feat/foundry-spine` (#78), so the diff is cleanest once that's merged — happy to
rebase onto `main` as soon as it goes in.

## Note on CI

The red checks are **fork-PR limits, not this code**: the Claude review action can't get an OIDC
token on PRs from forks, and `test.yml`'s "Comment PR" step can't post from a fork's read-only
token. The actual build/lint/test jobs pass.

## Screenshot — the card in Teams

Roll-up posted back into the channel after the run — the counts, every item linked, and a "confirm back with the team" section so people in the meeting can correct what was logged:
<img width="1710" alt="Teams Adaptive Card" src="https://github.com/user-attachments/assets/dd6d9d2d-6bf3-4840-875b-c042216c0ff3" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)

