### PR TITLE
feat(agent): production-grade VTT speaker attribution parser

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -1,0 +1,70 @@
+# Preppie spine — transcript → triaged Azure DevOps backlog
+
+The meeting-to-backlog core. A transcript goes in; a well-triaged, deduped, hierarchical Azure
+DevOps backlog comes out. This is the implementation of the Azure AI Foundry migration (#62) and
+the "actually reason over the transcript" behaviour (#27).
+
+## Architecture
+
+```
+transcript.vtt
+   │  parse_vtt (speaker attribution preserved)
+   ▼
+run_spine ──────────────► Azure AI Foundry (Responses API, gpt-5-mini)
+   ▲  function calls          │  instructions compiled from the T-Minus-15 workitems SKILL
+   │  tool outputs            ▼
+Backend (deployed Azure Functions) ──► Azure DevOps work items
+   read_projects · search_work_items (dedupe) · create_work_item · link_work_items
+```
+
+**Why the Responses API + a thin loop (not a middleware service).** The earlier design used an
+OpenAI resource-level *assistant*, whose function calls surface as a `requires_action` run that a
+separate long-running handler must service — the "missing piece" the old docs describe. The Foundry
+agent here uses the **Responses API**: `run_spine` is a stateless loop that receives the model's
+function calls, calls the deployed backend, and feeds the results back. No extra deployed component.
+
+**Why instructions are compiled, not hand-written.** `build_instructions.py` pulls the canonical
+sections (six work item types, triage, title hygiene, dedupe, reply-back) straight out of the
+T-Minus-15 `workitems` SKILL and wraps them with this deployment's runtime contract. The methodology
+stays the single source of truth; regenerate when it changes.
+
+## Model & type mapping
+
+- Model: **gpt-5-mini** (see `config.py`). gpt-4o is not deployable on this subscription's quota;
+  gpt-5-mini is current-gen and strong at tool-calling. One-line swap via `PREPPIE_MODEL`.
+- The Agile process template has native Task, Bug, Issue, Epic, Feature, User Story but **no**
+  Enhancement/Risk/Question type, so those map to Task/Issue **+ a tag** (`Enhancement`, `Risk`,
+  `Question`) — filterable, no custom process required. Full table in `preppie_instructions.md`.
+
+## Run it
+
+```bash
+# one-time: compile the instructions from a checkout of T-Minus-15/claude-plugins
+SKILLS_DIR=/path/to/claude-plugins/skills python agent/build_instructions.py > agent/preppie_instructions.md
+
+# run the spine over a transcript (uses your `az login` identity; no keys)
+python -m agent.cli path/to/meeting.vtt
+```
+
+Configuration (all optional, see `config.py`): `PREPPIE_FOUNDRY_OPENAI_ENDPOINT`, `PREPPIE_MODEL`,
+`PREPPIE_API_VERSION`, `PREPPIE_BACKEND_URL`, `PREPPIE_PROJECT`, `PREPPIE_INSTRUCTIONS_PATH`.
+
+## Tests
+
+```bash
+python -m pytest agent/tests/ -q
+```
+
+The backend and the LLM client are injected, so the parser, tool dispatch, and the full tool loop
+(dedupe-before-create, result collection, termination) are tested with no network access.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `spine.py` | `parse_vtt`, `Backend` (tool dispatch), `run_spine` (the loop) — the testable core |
+| `build_instructions.py` | compiles the system prompt from the T-Minus-15 SKILLs |
+| `preppie_instructions.md` | the compiled instructions (committed artifact) |
+| `config.py` | env-overridable deployment settings |
+| `cli.py` | wires the real Azure client + backend and runs a transcript |
+| `tests/` | unit tests + the sample transcript fixture |

--- a/agent/build_instructions.py
+++ b/agent/build_instructions.py
@@ -1,0 +1,102 @@
+"""
+Compile Preppie's agent instructions FROM the T-Minus-15 SKILL.md files.
+
+This is the heart of the Foundry migration (#62): the methodology is the source of truth, not a
+hand-maintained agent-config.json. We pull the canonical sections out of the `workitems` skill and
+wrap them with the deployment-specific runtime contract (tools, target project, the type ->
+Azure DevOps mapping for this process template, dedupe, hierarchy, reply-back, title hygiene).
+
+The T-Minus-15 skills live in a separate repo (T-Minus-15/claude-plugins). Point SKILLS_DIR at a
+checkout of it; the compiled result is committed alongside as `preppie_instructions.md` so the agent
+can be deployed without that checkout, and re-compiled whenever the methodology changes:
+
+    SKILLS_DIR=/path/to/claude-plugins/skills python agent/build_instructions.py > agent/preppie_instructions.md
+"""
+import os
+import re
+
+SKILLS = os.environ.get("SKILLS_DIR", os.path.expanduser("~/t-minus-15-claude-plugins/skills"))
+
+
+def section(skill: str, heading: str) -> str:
+    """Return the markdown block under a '## heading' (up to the next '## ') from a SKILL.md."""
+    path = os.path.join(SKILLS, skill, "SKILL.md")
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    text = re.sub(r"^---.*?---\n", "", text, count=1, flags=re.DOTALL)  # strip frontmatter
+    pat = re.compile(rf"^##\s+{re.escape(heading)}\s*$(.*?)(?=^##\s|\Z)", re.MULTILINE | re.DOTALL)
+    m = pat.search(text)
+    if not m:
+        raise SystemExit(f"[build] section '{heading}' not found in {skill}/SKILL.md")
+    return f"## {heading}\n{m.group(1).rstrip()}\n"
+
+
+HEADER = """# Preppie the Prepper - agent instructions
+
+You are **Preppie the Prepper**, the T-Minus-15 requirements/backlog agent. You turn a meeting
+transcript into a clean, well-triaged Azure DevOps backlog. You are precise, never invent facts,
+and you follow the T-Minus-15 methodology below (these rules are compiled from the T-Minus-15
+`workitems` skill and its per-type skills - they are the source of truth).
+
+## Your job for each run
+1. Read the transcript. Enumerate every actionable item raised, with who raised it and any owner.
+2. Triage each item to a type (see "The six work item types" + "Triage" below).
+3. Build the backlog structure (Epic -> Feature -> User Story) when the discussion implies it, and
+   attach the captured items under the right parent.
+4. BEFORE creating anything, DEDUPE: call `search_work_items` (titleContains) to check the item
+   doesn't already exist. Skip creation if a clear match exists; say so in your summary.
+5. Create each item with `create_work_item`, then link children to parents with `link_work_items`.
+6. End with a reply-back roll-up table mapping each thing raised -> what you logged (see format).
+
+## Runtime contract (this deployment)
+- Target project is **"Preppie"** in Azure DevOps org `ayush866`. Confirm with `read_projects`
+  if unsure; do not assume any other project.
+- You act ONLY through the provided tools. Never fabricate work item IDs or URLs - use what the
+  `create_work_item` tool returns.
+- **Type -> Azure DevOps mapping** (this project's Agile process template has native Task, Bug,
+  Issue, Epic, Feature, User Story - but NO native Enhancement/Risk/Question type). Map as:
+  | Triage type | `type` to pass | `tags` to pass |
+  |---|---|---|
+  | Task | `Task` | - |
+  | Bug | `Bug` | - |
+  | Issue | `Issue` | - |
+  | Enhancement | `Task` | `["Enhancement"]` |
+  | Risk | `Issue` | `["Risk"]` |
+  | Question | `Issue` | `["Question"]` |
+  | Epic / Feature / User Story | `Epic` / `Feature` / `User Story` | - |
+  Always set the tag when the mapping requires it, so the item stays filterable as its real type.
+- **Linking - attach to the nearest relevant parent.** Link every captured item to the MOST
+  specific parent that fits: a User Story if one applies, otherwise its Feature, otherwise the
+  Epic. A Bug/Task/Enhancement that affects a specific story must hang off that User Story, not the
+  Epic, when such a story exists.
+- Pass acceptance criteria ONLY on User Stories, via `acceptanceCriteria` (a list of strings), in
+  AMP form (Acceptance / Measure / Proof).
+- Keep descriptions rich enough that someone picking the item up cold understands it: what was
+  said, who raised it, why, and what "done" looks like. Never log a bare title.
+
+## Title hygiene (deployment-specific)
+- **Do NOT prefix a title with its type** ("Risk:", "Question:", "Bug:" ...). The work item type
+  and tag already convey that - the title states the thing itself.
+- Otherwise follow the "Title hygiene (all types)" rules below.
+
+## Output
+When all items are logged, output ONLY the reply-back summary described in "Reply-back convention"
+below: a one-line-per-item list, then the roll-up cross-reference table. Note any renames (title
+hygiene) and any items you skipped as duplicates.
+"""
+
+
+def compile_instructions() -> str:
+    parts = [HEADER, "\n---\n\n# Methodology (compiled from the T-Minus-15 skills)\n"]
+    parts.append(section("workitems", "Safety rules (before you log anything)"))
+    parts.append(section("workitems", "The six work item types"))
+    parts.append(section("workitems", "Triage: deciding the type"))
+    parts.append(section("workitems", "Capture flow (meetings & stand-ups)"))
+    parts.append(section("workitems", "Title hygiene (all types)"))
+    parts.append(section("workitems", "Writing the description"))
+    parts.append(section("workitems", "Reply-back convention (important)"))
+    return "\n\n".join(p.strip() for p in parts)
+
+
+if __name__ == "__main__":
+    print(compile_instructions())

--- a/agent/cli.py
+++ b/agent/cli.py
@@ -1,0 +1,43 @@
+"""
+Run the Preppie spine over a transcript file:
+
+    python -m agent.cli path/to/meeting.vtt
+
+Authenticates to Azure AI Foundry with your `az login` identity (DefaultAzureCredential), so no
+keys are handled here. Reads deployment settings from agent/config.py (env-overridable).
+"""
+import sys
+
+from azure.identity import DefaultAzureCredential, get_bearer_token_provider
+from openai import AzureOpenAI
+
+from . import config
+from .spine import Backend, read_transcript, run_spine
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: python -m agent.cli <transcript.vtt>", file=sys.stderr)
+        return 2
+
+    transcript = read_transcript(argv[1])
+    with open(config.INSTRUCTIONS_PATH, encoding="utf-8") as f:
+        instructions = f.read()
+
+    token_provider = get_bearer_token_provider(DefaultAzureCredential(), config.TOKEN_SCOPE)
+    client = AzureOpenAI(azure_endpoint=config.FOUNDRY_OPENAI_ENDPOINT,
+                         azure_ad_token_provider=token_provider, api_version=config.API_VERSION)
+    backend = Backend(config.BACKEND_URL, config.PROJECT)
+
+    result = run_spine(transcript, instructions, client, backend, config.MODEL,
+                       on_event=lambda m: print(f"  [tool] {m}", flush=True))
+
+    print("\n===================== PREPPIE REPLY-BACK =====================\n")
+    print(result["reply_back"])
+    print(f"\n[summary] created {len(result['created'])} work items in '{config.PROJECT}' "
+          f"over {result['turns']} turns.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/agent/config.py
+++ b/agent/config.py
@@ -1,0 +1,26 @@
+"""Deployment configuration for the Preppie spine - all overridable via environment variables."""
+import os
+
+# Azure AI Foundry resource's Azure OpenAI endpoint (Responses API lives here).
+FOUNDRY_OPENAI_ENDPOINT = os.environ.get(
+    "PREPPIE_FOUNDRY_OPENAI_ENDPOINT", "https://preppie-foundry-ayush866.openai.azure.com/")
+
+# Model deployment name on that resource.
+MODEL = os.environ.get("PREPPIE_MODEL", "gpt-5-mini")
+
+# API version that exposes the Responses API.
+API_VERSION = os.environ.get("PREPPIE_API_VERSION", "2025-04-01-preview")
+
+# Deployed Azure Functions backend (the Azure DevOps tool surface).
+BACKEND_URL = os.environ.get(
+    "PREPPIE_BACKEND_URL", "https://preppie-backend-ayush866-prod.azurewebsites.net")
+
+# Target Azure DevOps project.
+PROJECT = os.environ.get("PREPPIE_PROJECT", "Preppie")
+
+# Compiled agent instructions (see build_instructions.py).
+INSTRUCTIONS_PATH = os.environ.get(
+    "PREPPIE_INSTRUCTIONS_PATH", os.path.join(os.path.dirname(__file__), "preppie_instructions.md"))
+
+# AAD scope for the Foundry data plane.
+TOKEN_SCOPE = os.environ.get("PREPPIE_TOKEN_SCOPE", "https://cognitiveservices.azure.com/.default")

--- a/agent/preppie_instructions.md
+++ b/agent/preppie_instructions.md
@@ -1,0 +1,141 @@
+# Preppie the Prepper - agent instructions
+
+You are **Preppie the Prepper**, the T-Minus-15 requirements/backlog agent. You turn a meeting
+transcript into a clean, well-triaged Azure DevOps backlog. You are precise, never invent facts,
+and you follow the T-Minus-15 methodology below (these rules are compiled from the T-Minus-15
+`workitems` skill and its per-type skills - they are the source of truth).
+
+## Your job for each run
+1. Read the transcript. Enumerate every actionable item raised, with who raised it and any owner.
+2. Triage each item to a type (see "The six work item types" + "Triage" below).
+3. Build the backlog structure (Epic -> Feature -> User Story) when the discussion implies it, and
+   attach the captured items under the right parent.
+4. BEFORE creating anything, DEDUPE: call `search_work_items` (titleContains) to check the item
+   doesn't already exist. Skip creation if a clear match exists; say so in your summary.
+5. Create each item with `create_work_item`, then link children to parents with `link_work_items`.
+6. End with a reply-back roll-up table mapping each thing raised -> what you logged (see format).
+
+## Runtime contract (this deployment)
+- Target project is **"Preppie"** in Azure DevOps org `ayush866`. Confirm with `read_projects`
+  if unsure; do not assume any other project.
+- You act ONLY through the provided tools. Never fabricate work item IDs or URLs - use what the
+  `create_work_item` tool returns.
+- **Type -> Azure DevOps mapping** (this project's Agile process template has native Task, Bug,
+  Issue, Epic, Feature, User Story - but NO native Enhancement/Risk/Question type). Map as:
+  | Triage type | `type` to pass | `tags` to pass |
+  |---|---|---|
+  | Task | `Task` | - |
+  | Bug | `Bug` | - |
+  | Issue | `Issue` | - |
+  | Enhancement | `Task` | `["Enhancement"]` |
+  | Risk | `Issue` | `["Risk"]` |
+  | Question | `Issue` | `["Question"]` |
+  | Epic / Feature / User Story | `Epic` / `Feature` / `User Story` | - |
+  Always set the tag when the mapping requires it, so the item stays filterable as its real type.
+- **Linking - attach to the nearest relevant parent.** Link every captured item to the MOST
+  specific parent that fits: a User Story if one applies, otherwise its Feature, otherwise the
+  Epic. A Bug/Task/Enhancement that affects a specific story must hang off that User Story, not the
+  Epic, when such a story exists.
+- Pass acceptance criteria ONLY on User Stories, via `acceptanceCriteria` (a list of strings), in
+  AMP form (Acceptance / Measure / Proof).
+- Keep descriptions rich enough that someone picking the item up cold understands it: what was
+  said, who raised it, why, and what "done" looks like. Never log a bare title.
+
+## Title hygiene (deployment-specific)
+- **Do NOT prefix a title with its type** ("Risk:", "Question:", "Bug:" ...). The work item type
+  and tag already convey that - the title states the thing itself.
+- Otherwise follow the "Title hygiene (all types)" rules below.
+
+## Output
+When all items are logged, output ONLY the reply-back summary described in "Reply-back convention"
+below: a one-line-per-item list, then the roll-up cross-reference table. Note any renames (title
+hygiene) and any items you skipped as duplicates.
+
+---
+
+# Methodology (compiled from the T-Minus-15 skills)
+
+## Safety rules (before you log anything)
+
+Logging into a shared tracker is easy to get wrong in ways that are hard to undo. Always:
+
+1. **Check before you create** — query the tracker first to avoid duplicate items. Duplicates cause confusion and waste effort.
+2. **Never hard-delete** — set state to "Removed"/closed instead. Deletion is irreversible and loses history.
+3. **Don't quietly amend an active Epic's backlog** — adding/removing Features on an Epic already underway changes the scope of in-progress work. Confirm with the requester (and, for client work, the customer) first.
+4. **Ask when unsure** — if you're not certain of the project, area path, owner, or whether something should be created at all, ask before acting (`AskUserQuestion`).
+
+## The six work item types
+
+| Type | Use for | Skill |
+|------|---------|-------|
+| **Task** | A concrete action/to-do with a clear owner | `task` |
+| **Bug** | Something is broken vs expected behaviour | `bug` |
+| **Enhancement** | Improve existing functionality | `enhancement` |
+| **Risk** | Something that *might* go wrong (impact + mitigation) | `risk` |
+| **Issue** | Something that *is* going wrong / a blocker (impact + resolution) | `issue` |
+| **Question** | A clarification needed before work can proceed (needs an owner) | `question` |
+
+(Epics, Features and User Stories are backlog structure — use the `epic`, `feature`, `user-story` skills for those.)
+
+## Triage: deciding the type
+
+For each item raised, ask:
+1. Is it broken right now? → **Bug** (or **Issue** if it's a process/delivery blocker rather than a code defect).
+2. Is it a "might happen" concern? → **Risk** (capture impact + mitigation).
+3. Is it "make the existing thing better"? → **Enhancement**.
+4. Is it an open question blocking progress? → **Question** (assign an owner).
+5. Otherwise, a plain action with an owner → **Task**.
+
+When the type is genuinely ambiguous, use `AskUserQuestion` rather than guessing.
+
+## Capture flow (meetings & stand-ups)
+
+1. **Read the source** — meeting chat, transcript, or notes. Enumerate each actionable item with who raised it and any owner mentioned.
+2. **Scope discipline** — only log the items you've been explicitly asked to. For items raised by *other* people, or where ownership is unclear, **flag and confirm before logging** — do not assume. ("These three are yours; I'll log them. Two others were raised by colleagues — want me to log those too?")
+3. **Decide the type** for each (triage above).
+4. **Sanitise the title** (see Title hygiene) — professional, client-safe wording.
+5. **Write a meaningful description** (see Writing the description). If the item was raised in a meeting, **read the meeting transcript / chat / notes** — or delegate a sub-agent via `Task` — to capture the context, decisions and acceptance detail, rather than logging a bare one-liner.
+6. **Log** each item in the tracker (title + description + owner + parent link).
+7. **Reply back** in the thread, and **summarise** to the requester (see Reply-back convention).
+
+## Title hygiene (all types)
+
+Every work item title must be **safe to share with a client** and professional, regardless of how it's created (including ad-hoc via `az boards`):
+- Rephrase internal slang/shorthand — "Chase X" → "Follow up X".
+- Prefer a **role or company** over an individual's personal name where possible.
+- Avoid HR/immigration/visa specifics, and commercially sensitive detail (rates, margins).
+- Keep it concise and outcome-oriented.
+
+If you change the wording from what was said, note it in the reply-back (so the requester can see "Chase HRB" was logged as "Follow up HRB").
+
+## Writing the description
+
+A work item is only useful if its description carries the context — **don't leave it blank or log just a title.**
+
+- **Aim for enough detail that someone picking it up cold understands it** — the background, what "done" looks like, and any links (related work items, documents, the PR/repo).
+- **Meeting-created items:** if it came out of a meeting or stand-up, **look at the transcript / chat / notes** to enrich the description — who asked for it, why, and any decisions or acceptance detail discussed. For a long transcript, **delegate a sub-agent via `Task`** to read it and draft the description, then review before logging.
+- **Match the type's fields** (see Per-type specifics) — a Bug needs repro steps; a Risk needs impact + mitigation; etc.
+- Keep it client-safe (same rules as titles).
+
+## Reply-back convention (important)
+
+After logging, do **two** reply-backs:
+
+**1. In the meeting thread / chat** — quote the person's original comment and reply with the linked item, so the action and its tracker entry sit together:
+
+> [Task 1234](https://dev.azure.com/<your-org>/<project>/_workitems/edit/1234): Create partnership document (`<project>`)
+
+Format: **`[<Type> <ID>](url): <Title> (<project>[ — assigned to <name>])`**, where `<Type> <ID>` is the hyperlink. Append the assignee when it's someone other than the requester.
+
+**2. Summarise back to the requester** — one line per item, then a roll-up table:
+
+> - **#1234 — Create partnership document** (Task, `<project>`, assigned to <name>, State: New) — [open](https://.../edit/1234)
+
+Roll-up + cross-reference table (so each thing raised maps to what was logged):
+
+> | Raised | Logged as | Link |
+> |---|---|---|
+> | Create partnership doc | Task **1234** | [edit/1234](https://.../edit/1234) |
+> | Chase supplier for quote | Task **1235** (titled "Follow up supplier quote") | [edit/1235](https://.../edit/1235) |
+
+Use ✅ to confirm an *action completed* ("Logged and posted ✅"), not as a per-item prefix.

--- a/agent/spine.py
+++ b/agent/spine.py
@@ -1,0 +1,199 @@
+"""
+Preppie spine - transcript -> Azure AI Foundry agent (Responses API) -> triaged Azure DevOps
+backlog, with dedupe.
+
+This is the meeting-to-backlog core (#27 + #62): the agent reasons over the transcript and drives
+the deployed backend tools. Tool-calling is a thin, stateless loop - no separate long-running
+middleware. Both the LLM client and the backend are injected, so the loop is unit-testable without
+network access (see tests/test_spine.py).
+"""
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+import urllib.error
+from typing import Any, Callable
+
+
+# ---------- transcript parsing ----------
+def parse_vtt(text: str) -> str:
+    """Flatten a WEBVTT transcript to 'Speaker: text' lines (drops cue numbers/timestamps)."""
+    lines = []
+    for raw in text.splitlines():
+        s = raw.strip()
+        if not s or s == "WEBVTT" or "-->" in s or s.isdigit():
+            continue
+        head, sep, tail = s.replace("<v ", "").partition(">")
+        if sep:  # had a <v Name> voice tag
+            lines.append(f"{head.strip()}: {tail.strip()}")
+        else:
+            lines.append(s)
+    return "\n".join(lines)
+
+
+def read_transcript(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        text = f.read()
+    return parse_vtt(text) if path.lower().endswith(".vtt") else text
+
+
+# ---------- backend tool dispatch ----------
+class Backend:
+    """Calls the deployed Azure Functions backend. Every call is scoped to one project."""
+
+    def __init__(self, base_url: str, project: str, opener: Callable | None = None,
+                 attempts: int = 4):
+        self.base_url = base_url.rstrip("/")
+        self.project = project
+        self._opener = opener or urllib.request.urlopen
+        self._attempts = attempts
+
+    def _request(self, path: str, method: str, body: dict | None) -> dict:
+        # Retry transient connection blips and 5xx (Flex Consumption cold-scale can drop a
+        # connection); a single hiccup must not abort a whole meeting's backlog.
+        data = json.dumps(body).encode() if body is not None else None
+        for attempt in range(self._attempts):
+            req = urllib.request.Request(
+                f"{self.base_url}{path}", data=data, method=method,
+                headers={"Content-Type": "application/json"})
+            try:
+                with self._opener(req, timeout=45) as r:
+                    return json.loads(r.read().decode())
+            except urllib.error.HTTPError as e:
+                if e.code >= 500 and attempt < self._attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                return {"success": False, "error": f"HTTP {e.code}: {e.read().decode()[:300]}"}
+            except urllib.error.URLError as e:
+                if attempt < self._attempts - 1:
+                    time.sleep(1.5 * (attempt + 1))
+                    continue
+                return {"success": False, "error": f"connection error after {self._attempts} tries: {e}"}
+        return {"success": False, "error": "no request attempts made (attempts must be >= 1)"}
+
+    def dispatch(self, name: str, args: dict) -> dict:
+        """Route a tool call to the backend, injecting the project. Returns the backend JSON."""
+        if name == "read_projects":
+            return self._request("/api/read_projects", "GET", None)
+        if name == "search_work_items":
+            return self._request("/api/search_work_items", "POST", {**args, "project": self.project})
+        if name == "create_work_item":
+            return self._request("/api/create_work_item", "POST", {**args, "project": self.project})
+        if name == "link_work_items":
+            return self._request("/api/link_work_items", "POST", {**args, "project": self.project})
+        return {"success": False, "error": f"unknown tool {name}"}
+
+
+# ---------- tool schemas (match the deployed backend contract) ----------
+TOOLS: list[dict[str, Any]] = [
+    {"type": "function", "name": "read_projects",
+     "description": "List Azure DevOps projects in the org. Use to confirm the target project exists.",
+     "parameters": {"type": "object", "properties": {}, "required": []}},
+    {"type": "function", "name": "search_work_items",
+     "description": "Search existing work items in the target project. Use for DEDUPE before creating "
+                    "(titleContains), and to find a just-created parent.",
+     "parameters": {"type": "object", "properties": {
+         "titleContains": {"type": "string", "description": "Substring to match in the title."},
+         "workItemType": {"type": "string", "description": "Filter by type e.g. Task, Bug, Issue, Epic, Feature, User Story."},
+         "state": {"type": "string"},
+         "tags": {"type": "string", "description": "Substring to match in the item's tags (e.g. 'Risk')."},
+         "top": {"type": "integer"}}, "required": []}},
+    {"type": "function", "name": "create_work_item",
+     "description": "Create one work item in the target project. Returns its id and url. "
+                    "Apply the type->ADO mapping and tags from your instructions.",
+     "parameters": {"type": "object", "properties": {
+         "type": {"type": "string", "description": "Azure DevOps type: Task, Bug, Issue, Epic, Feature, or User Story."},
+         "title": {"type": "string", "description": "Clean, client-safe title (no type prefix)."},
+         "description": {"type": "string", "description": "Rich description: context, who raised it, definition of done."},
+         "acceptanceCriteria": {"type": "array", "items": {"type": "string"},
+                                 "description": "User Stories only. AMP form (Acceptance/Measure/Proof)."},
+         "tags": {"type": "array", "items": {"type": "string"},
+                  "description": "Triage tag when the native type differs, e.g. ['Enhancement'], ['Risk'], ['Question']."},
+         "priority": {"type": "integer", "description": "1 (highest) to 4."},
+         "estimatedEffort": {"type": "string", "description": "Optional effort/size estimate, e.g. '3', '5', '8'."}},
+         "required": ["type", "title", "description"]}},
+    {"type": "function", "name": "link_work_items",
+     "description": "Link a parent to child work items (parent-child hierarchy). "
+                    "sourceId = parent id, targetIds = child ids.",
+     "parameters": {"type": "object", "properties": {
+         "sourceId": {"type": "integer", "description": "Parent work item id."},
+         "targetIds": {"type": "array", "items": {"type": "integer"}, "description": "Child work item ids."},
+         "linkType": {"type": "string", "description": "Default System.LinkTypes.Hierarchy-Forward (parent->child)."}},
+         "required": ["sourceId", "targetIds"]}},
+]
+
+USER_PROMPT = (
+    "Process this meeting transcript into the backlog now. Dedupe before creating, build the "
+    "Epic/Feature/User Story structure, attach captured items under the nearest relevant parent, "
+    "and finish with the reply-back roll-up table.\n\n=== TRANSCRIPT ===\n"
+)
+
+
+def run_spine(transcript: str, instructions: str, client, backend: Backend, model: str,
+              *, on_event: Callable[[str], None] | None = None, max_turns: int = 30) -> dict:
+    """
+    Drive the Responses-API tool loop until the model stops calling tools.
+
+    `client` must expose `responses.create(...)` (an openai AzureOpenAI, or a fake in tests).
+    Returns {created: [...backend results...], reply_back: str, turns: int}.
+    """
+    def emit(msg: str) -> None:
+        if on_event:
+            on_event(msg)
+
+    resp = client.responses.create(
+        model=model, instructions=instructions,
+        input=[{"role": "user", "content": USER_PROMPT + transcript}], tools=TOOLS)
+
+    created: list[dict] = []
+    truncated = False
+    turns = 0
+    for turns in range(1, max_turns + 1):
+        calls = [o for o in resp.output if getattr(o, "type", None) == "function_call"]
+        if not calls:
+            break
+        outputs = []
+        for c in calls:
+            try:
+                args = json.loads(c.arguments or "{}")
+                if not isinstance(args, dict):
+                    raise ValueError(f"expected a JSON object, got {type(args).__name__}")
+            except (json.JSONDecodeError, ValueError) as e:
+                # A malformed tool call must not kill the whole run (and every call_id still
+                # needs a matching output, or the next Responses API call is invalid) - report
+                # it back to the model as a failed call and move on.
+                result = {"success": False, "error": f"malformed arguments for {c.name}: {e}"}
+                emit(f"BAD ARGS for {c.name}: {c.arguments!r} ({e})")
+                outputs.append({"type": "function_call_output", "call_id": c.call_id,
+                                 "output": json.dumps(result)})
+                continue
+            result = backend.dispatch(c.name, args)
+            if c.name == "create_work_item" and result.get("success"):
+                created.append(result)
+                emit(f"create {result['work_item_type']} #{result['work_item_id']}: {result['title']}")
+            elif c.name == "create_work_item":
+                emit(f"CREATE FAILED: {result.get('error')}")
+            elif c.name == "search_work_items":
+                emit(f"dedupe '{args.get('titleContains', '')}' -> {result.get('count', '?')} match(es)")
+            elif c.name == "link_work_items":
+                emit(f"link parent {args.get('sourceId')} -> {args.get('targetIds')}")
+            outputs.append({"type": "function_call_output", "call_id": c.call_id, "output": json.dumps(result)})
+        resp = client.responses.create(
+            model=model, instructions=instructions,
+            previous_response_id=resp.id, input=outputs, tools=TOOLS)
+    else:
+        # The for-loop ran out of turns without ever hitting the `break` above, i.e. the model
+        # was still calling tools when the budget ran out. The last resp we just got back may
+        # itself carry unserviced function_calls and therefore no real reply_back text - don't
+        # let that surface as a silent blank summary when items may already have been created.
+        pending = [o for o in resp.output if getattr(o, "type", None) == "function_call"]
+        if pending:
+            truncated = True
+            emit(f"max_turns ({max_turns}) reached with {len(pending)} pending tool call(s); stopping")
+
+    reply_back = resp.output_text
+    if truncated and not reply_back:
+        reply_back = (f"[Preppie stopped after {max_turns} turns without a final reply - "
+                       f"{len(created)} item(s) were created; check Azure DevOps directly.]")
+    return {"created": created, "reply_back": reply_back, "turns": turns}

--- a/agent/spine.py
+++ b/agent/spine.py
@@ -9,7 +9,9 @@ network access (see tests/test_spine.py).
 """
 from __future__ import annotations
 
+import html
 import json
+import re
 import time
 import urllib.request
 import urllib.error
@@ -17,19 +19,221 @@ from typing import Any, Callable
 
 
 # ---------- transcript parsing ----------
-def parse_vtt(text: str) -> str:
-    """Flatten a WEBVTT transcript to 'Speaker: text' lines (drops cue numbers/timestamps)."""
-    lines = []
-    for raw in text.splitlines():
-        s = raw.strip()
-        if not s or s == "WEBVTT" or "-->" in s or s.isdigit():
+# Speaker attribution is the whole point of this parser (#see task): the downstream agent needs
+# to know WHO raised each item and WHO owns it, so getting "who said this" wrong is worse than
+# getting formatting wrong. Real-world VTT exports (Teams and otherwise) disagree on nearly every
+# optional piece of the spec - cue ids, voice classes, BOMs, line endings - so this is written to
+# be lenient and never raise rather than strictly validate.
+
+# Teams/other exporters sometimes emit a UTF-8 BOM before "WEBVTT" - strip it so the header check
+# below doesn't fail to recognize an otherwise-valid file.
+_BOM = "﻿"
+
+# The WEBVTT header line can carry trailing metadata (e.g. "WEBVTT - Meeting recording") - match
+# the whole line so it's dropped either way, not just the bare "WEBVTT" seen in toy examples.
+_HEADER_RE = re.compile(r"^WEBVTT([ \t].*)?$")
+
+# NOTE/STYLE/REGION are metadata blocks, not dialogue. Each runs from its keyword line through to
+# the next blank line (or EOF) and must never leak into the transcript as if someone had said it.
+_NOTE_RE = re.compile(r"^NOTE([ \t]|$)")
+_METADATA_KEYWORDS = ("STYLE", "REGION")
+
+# A real timing line is "<timestamp> --> <timestamp>" (optionally with trailing cue settings,
+# ignored here via prefix match) - MM:SS.mmm or HH:MM:SS.mmm on both sides. This used to be a
+# bare `"-->" in line` substring test, which misfires on ordinary dialogue that happens to
+# contain a literal "-->" (e.g. someone says "a --> b") and silently drops the utterance.
+_TIMING_RE = re.compile(
+    r"^\d{2,}:\d{2}(?::\d{2})?\.\d{3}\s*-->\s*\d{2,}:\d{2}(?::\d{2})?\.\d{3}")
+
+# A voice span looks like <v[.class[.class...]] Speaker Name>text</v>. Real exporters add
+# cue-styling classes (e.g. <v.loud Alice>) that a naive "<v " prefix strip misses entirely, and
+# the trailing </v> is easy to forget to strip (leaving it stuck onto the end of the utterance).
+# The class char class deliberately excludes "." (not just space/tab/">") - allowing "." inside
+# a repeated group here is a classic ReDoS trap: on an unterminated "<v" followed by a long run
+# of dots, the engine can partition that run across the `(?:\...)*` repetition in exponentially
+# many ways before concluding there's no final ">", hanging for effectively ever. Excluding "."
+# forces a single, unambiguous partition (one dot begins each iteration) so matching stays linear.
+_VOICE_OPEN_RE = re.compile(r"<v(?:\.[^ \t>.]+)*(?:[ \t]+([^>]*))?>", re.IGNORECASE)
+
+# Inline styling tags (<i>, <b>, <u>, <c.class>, <ruby>, <rt>, <lang xx>, plus the closing </v>)
+# carry no content of their own - strip the markup, keep the words that were inside it.
+_INLINE_TAG_RE = re.compile(r"</?[A-Za-z][^>]*>")
+
+# Karaoke-style inline word timestamps, e.g. <00:00:01.500>. These start with a digit, so the
+# generic tag stripper above (which requires a letter after "<") deliberately doesn't catch them.
+_INLINE_TIMESTAMP_RE = re.compile(r"<\d{1,2}:\d{2}(?::\d{2})?\.\d{3}>")
+
+# Collapse runs of literal whitespace left behind by multi-line joins / tag stripping. This is
+# deliberately NOT str.split()/join(), which would also swallow a decoded &nbsp; (U+00A0) - once
+# decoded that's a real character in what the speaker said, not layout whitespace to discard.
+_WHITESPACE_RE = re.compile(r"[ \t\r\n\f\v]+")
+
+UNKNOWN_SPEAKER = "Unknown"  # attribution used when a <v> tag is present but carries no name
+
+
+def _clean_cue_text(raw: str) -> str:
+    """Strip inline cue markup/timestamps from one utterance and decode HTML entities.
+
+    Tags are replaced with a space, not deleted outright - e.g. "<ruby>base<rt>ann</rt></ruby>"
+    has no whitespace around the inner tag, and a bare delete would fuse it into "baseann". The
+    extra whitespace this introduces elsewhere is harmless since it's collapsed right after.
+    """
+    text = _INLINE_TIMESTAMP_RE.sub(" ", raw)
+    text = _INLINE_TAG_RE.sub(" ", text)
+    text = html.unescape(text)
+    return _WHITESPACE_RE.sub(" ", text).strip()
+
+
+def _split_voice_spans(full_text: str) -> list[tuple[str | None, str]]:
+    """Split one cue's (already line-joined) payload into (speaker, text) segments.
+
+    A single cue can contain more than one voice span - a speaker change mid-cue, e.g.
+    "<v Alice>Hi</v> <v Bob>Yo</v>" - so this returns a list, not a single segment. Text before
+    the first voice tag (if any) is genuinely un-attributed and comes back with speaker None.
+    """
+    opens = list(_VOICE_OPEN_RE.finditer(full_text))
+    if not opens:
+        text = _clean_cue_text(full_text)
+        return [(None, text)] if text else []
+
+    segments: list[tuple[str | None, str]] = []
+    if opens[0].start() > 0:
+        preamble = _clean_cue_text(full_text[: opens[0].start()])
+        if preamble:
+            segments.append((None, preamble))
+
+    for idx, m in enumerate(opens):
+        end = opens[idx + 1].start() if idx + 1 < len(opens) else len(full_text)
+        text = _clean_cue_text(full_text[m.end():end])
+        if not text:
             continue
-        head, sep, tail = s.replace("<v ", "").partition(">")
-        if sep:  # had a <v Name> voice tag
-            lines.append(f"{head.strip()}: {tail.strip()}")
+        # <v> / <v > (no name at all) is malformed but real - attribute it rather than crash
+        # or silently drop what was said. A malformed tag can also smuggle a stray "<"/">" into
+        # the captured name (e.g. "<v Alice <Manager>>Hi" - the regex's [^>]* stops at the first
+        # ">" it meets, capturing "Alice <Manager") - strip those out rather than let markup leak
+        # into what's supposed to be a plain speaker name.
+        name = re.sub(r"[<>]", "", (m.group(1) or "")).strip() or UNKNOWN_SPEAKER
+        segments.append((name, text))
+    return segments
+
+
+def parse_transcript_segments(text: str) -> list[tuple[str | None, str]]:
+    """
+    Parse a WEBVTT (or VTT-ish) transcript into (speaker, utterance) segments, in order.
+
+    speaker is None for genuinely un-attributed text (no <v> tag found anywhere for that line/
+    cue) so the caller can decide how to render it raw instead of inventing a name. Never raises.
+    """
+    try:
+        if not text:
+            return []
+        if text[0] == _BOM:
+            text = text[1:]
+        text = text.replace("\r\n", "\n").replace("\r", "\n")
+        lines = text.split("\n")
+        n = len(lines)
+        segments: list[tuple[str | None, str]] = []
+        i = 0
+
+        def skip_block(idx: int) -> int:
+            # Consume a NOTE/STYLE/REGION block: everything up to (and including) the next
+            # blank line, or EOF - whichever comes first.
+            idx += 1
+            while idx < n and lines[idx].strip() != "":
+                idx += 1
+            return idx + 1 if idx < n else idx
+
+        while i < n:
+            stripped = lines[i].strip()
+            if not stripped:
+                i += 1
+                continue
+            if _HEADER_RE.match(stripped):
+                i += 1
+                continue
+            if _NOTE_RE.match(stripped) or stripped in _METADATA_KEYWORDS:
+                # Per spec a metadata block's keyword line is never immediately followed by a
+                # timing line - only a genuine cue id is. So a bare "STYLE"/"REGION"/"NOTE" line
+                # sitting directly in front of a real timing line (no blank separator) is the far
+                # more likely case of "someone's cue id happened to be that word", not an actual
+                # metadata block - treat it as a (dropped) cue id instead of swallowing the real
+                # cue that follows. This is a best-effort disambiguation, not a proof: a transcript
+                # line that is genuinely a NOTE/STYLE/REGION block AND is immediately followed -
+                # with no blank line - by something that looks like a timing line is inherently
+                # indistinguishable from a cue id in this grammar; we deliberately favor the
+                # spec-compliant cue-id reading in that ambiguous case rather than add a fragile
+                # heuristic to tell them apart.
+                next_line = lines[i + 1].strip() if i + 1 < n else ""
+                if _TIMING_RE.match(next_line):
+                    i += 1
+                    continue
+                i = skip_block(i)
+                continue
+            if _TIMING_RE.match(stripped):
+                # Timing line (cue settings like "align:start position:0%" may trail it - the
+                # regex only matches the leading timestamps, so any trailing settings are ignored).
+                i += 1
+                payload: list[str] = []
+                while i < n and lines[i].strip() != "":
+                    payload.append(lines[i].strip())
+                    i += 1
+                while i < n and lines[i].strip() == "":
+                    i += 1
+                # A cue's payload can span several physical lines - they belong to the same
+                # speaker turn, so join them before splitting on voice tags, not one raw line each.
+                segments.extend(_split_voice_spans(" ".join(payload)))
+                continue
+            # Not a timing line - if the *next* line is one, this line is a cue identifier
+            # (numeric, "intro-1", a UUID, ...) that carries no text of its own and must not
+            # leak into the transcript.
+            if i + 1 < n and _TIMING_RE.match(lines[i + 1].strip()):
+                i += 1
+                continue
+            # No surrounding cue structure at all: a stray line, or already-flattened
+            # "Name: text" input. Pass it through unattributed rather than lose or mis-tag it.
+            segments.append((None, stripped))
+            i += 1
+        return segments
+    except Exception:
+        # A malformed transcript must never take down the caller's pipeline.
+        return [(None, text)] if isinstance(text, str) and text.strip() else []
+
+
+def _merge_consecutive_speakers(
+        segments: list[tuple[str | None, str]]) -> list[tuple[str | None, str]]:
+    """Merge adjacent segments from the same named speaker (typically consecutive cues).
+
+    This is the actual attribution payoff: an action item or acceptance criterion that spans
+    several cues stays under one person's line instead of fragmenting at every cue boundary.
+    Un-attributed (speaker None) segments are left as separate lines - there's no speaker
+    identity to merge on. UNKNOWN_SPEAKER segments are treated the same way: it's a placeholder
+    for "no name was given", not an actual identity, so two different unnamed speakers must not
+    be fused into one "Unknown:" turn just because the label happens to match.
+    """
+    merged: list[tuple[str | None, str]] = []
+    for speaker, text in segments:
+        if (merged and speaker is not None and speaker != UNKNOWN_SPEAKER
+                and merged[-1][0] == speaker):
+            prev_speaker, prev_text = merged[-1]
+            merged[-1] = (prev_speaker, f"{prev_text} {text}")
         else:
-            lines.append(s)
-    return "\n".join(lines)
+            merged.append((speaker, text))
+    return merged
+
+
+def parse_vtt(text: str) -> str:
+    """Flatten a WEBVTT transcript to 'Speaker: text' lines, one per merged speaker turn.
+
+    Un-attributable text is passed through raw (no invented speaker) rather than dropped -
+    losing what was said is worse than losing who said it. Never raises.
+    """
+    try:
+        merged = _merge_consecutive_speakers(parse_transcript_segments(text))
+        lines = [f"{speaker}: {utterance}" if speaker is not None else utterance
+                 for speaker, utterance in merged]
+        return "\n".join(lines)
+    except Exception:
+        return text if isinstance(text, str) else ""
 
 
 def read_transcript(path: str) -> str:

--- a/agent/tests/fixtures/sample-meeting.vtt
+++ b/agent/tests/fixtures/sample-meeting.vtt
@@ -1,0 +1,40 @@
+WEBVTT
+
+00:00:01.000 --> 00:00:08.200
+<v Priya Sharma>Okay, thanks for jumping on. The main thing I want to lock down today is the customer self-service portal for Q3. It's a big one — I'd call it our flagship initiative for the quarter.
+
+00:00:08.500 --> 00:00:15.000
+<v Daniel Okoro>Agreed. So at a high level the portal is the umbrella, and under it we've got at least the account management piece and the billing view. Those feel like two separate features to me.
+
+00:00:15.400 --> 00:00:24.800
+<v Priya Sharma>Right. For account management, the concrete thing customers keep asking for is: as a signed-in user I want to update my own contact details without raising a support ticket. That's a clear user story.
+
+00:00:25.100 --> 00:00:31.600
+<v Daniel Okoro>Makes sense. Given a logged-in user, when they change their email, then we send a confirmation link before it takes effect — otherwise we'll get account takeover complaints.
+
+00:00:32.000 --> 00:00:40.300
+<v Priya Sharma>Good, add that as the acceptance criteria. Now, separate thing — we already have a bug in the current portal. The session times out after about two minutes and dumps people back to login. It's been reported by three enterprise customers.
+
+00:00:40.700 --> 00:00:47.100
+<v Daniel Okoro>Yeah I've seen that one. It's the token refresh not firing. That's definitely a bug, not new work — we should log it and prioritise it high.
+
+00:00:47.500 --> 00:00:56.900
+<v Priya Sharma>One risk I want on the record: the billing view depends on the third-party invoicing API, and their rate limits are pretty aggressive. If we design the dashboard to call it live per page load, we could get throttled in production.
+
+00:00:57.300 --> 00:01:04.200
+<v Daniel Okoro>That's a real risk. We might need a caching layer. Actually — would it be worth caching invoices for, say, fifteen minutes? That'd cut the calls dramatically.
+
+00:01:04.600 --> 00:01:12.500
+<v Priya Sharma>That's a nice enhancement on top of the billing feature — let's capture it as an improvement rather than baking it into the core story for now.
+
+00:01:12.900 --> 00:01:21.400
+<v Daniel Okoro>One thing I'm genuinely unsure about: when we say "customers can manage their account", does that include deleting the account entirely? Because GDPR erasure is a whole separate workflow with legal sign-off.
+
+00:01:21.800 --> 00:01:29.000
+<v Priya Sharma>Good question — I don't have the answer. Let's flag that as an open question for legal before we scope the deletion flow. Don't guess at it.
+
+00:01:29.400 --> 00:01:36.700
+<v Daniel Okoro>Perfect. And a small task on my side — I'll set up the feature branch and the CI pipeline for the portal repo so we're ready to build. Nothing fancy, just the plumbing.
+
+00:01:37.000 --> 00:01:42.300
+<v Priya Sharma>Great. I think that's a solid backlog. Let's get it written up properly and we'll review it at standup tomorrow.

--- a/agent/tests/test_parse.py
+++ b/agent/tests/test_parse.py
@@ -1,0 +1,288 @@
+"""
+Speaker-attribution tests for the VTT parser in agent/spine.py.
+
+These target the negative/edge cases the naive parser got wrong (or never handled): malformed
+cue markup, mixed line endings, voice-tag variants, and metadata blocks that must not leak into
+the transcript. `test_spine.py` keeps the original exact-equality tests untouched; this file adds
+one test per documented edge case, named descriptively, with the negative case explicit.
+"""
+from agent.spine import parse_vtt, parse_transcript_segments, UNKNOWN_SPEAKER
+
+
+# ---------- header / BOM ----------
+def test_bom_prefix_before_webvtt_header_is_dropped():
+    vtt = "﻿WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v Alice>Hi\n"
+    assert parse_vtt(vtt) == "Alice: Hi"
+
+
+def test_webvtt_header_with_trailing_text_is_dropped():
+    vtt = "WEBVTT - Meeting recording\n\n00:00:01.000 --> 00:00:02.000\n<v Alice>Hi\n"
+    out = parse_vtt(vtt)
+    assert "WEBVTT" not in out
+    assert out == "Alice: Hi"
+
+
+# ---------- NOTE / STYLE / REGION metadata blocks ----------
+def test_single_line_note_block_is_dropped():
+    vtt = ("WEBVTT\n\nNOTE this is a comment\n\n"
+           "00:00:01.000 --> 00:00:02.000\n<v Alice>Hi\n")
+    out = parse_vtt(vtt)
+    assert "comment" not in out
+    assert out == "Alice: Hi"
+
+
+def test_multi_line_note_block_terminated_by_blank_line_is_dropped():
+    vtt = ("WEBVTT\n\nNOTE\nThis spans\nseveral lines\n\n"
+           "00:00:01.000 --> 00:00:02.000\n<v Alice>Hi\n")
+    out = parse_vtt(vtt)
+    assert "spans" not in out and "several" not in out
+    assert out == "Alice: Hi"
+
+
+def test_style_block_body_does_not_leak_as_text():
+    vtt = ("WEBVTT\n\nSTYLE\n::cue { background: black; }\n\n"
+           "00:00:01.000 --> 00:00:02.000\n<v Alice>Hi\n")
+    out = parse_vtt(vtt)
+    assert "cue" not in out and "background" not in out
+    assert out == "Alice: Hi"
+
+
+def test_region_block_body_does_not_leak_as_text():
+    vtt = ("WEBVTT\n\nREGION\nid:fred\nwidth:40%\nlines:3\n\n"
+           "00:00:01.000 --> 00:00:02.000\n<v Alice>Hi\n")
+    out = parse_vtt(vtt)
+    assert "id:fred" not in out and "width" not in out
+    assert out == "Alice: Hi"
+
+
+# ---------- cue identifiers ----------
+def test_numeric_cue_identifier_is_dropped():
+    vtt = "WEBVTT\n\n3\n00:00:01.000 --> 00:00:02.000\n<v Alice>Hi\n"
+    assert parse_vtt(vtt) == "Alice: Hi"
+
+
+def test_alphanumeric_cue_identifier_is_dropped():
+    vtt = "WEBVTT\n\nintro-1\n00:00:01.000 --> 00:00:02.000\n<v Alice>Hi\n"
+    out = parse_vtt(vtt)
+    assert "intro-1" not in out
+    assert out == "Alice: Hi"
+
+
+def test_uuid_cue_identifier_is_dropped():
+    vtt = ("WEBVTT\n\n550e8400-e29b-41d4-a716-446655440000\n"
+           "00:00:01.000 --> 00:00:02.000\n<v Alice>Hi\n")
+    out = parse_vtt(vtt)
+    assert "550e8400" not in out
+    assert out == "Alice: Hi"
+
+
+# ---------- timestamp line with cue settings ----------
+def test_timestamp_line_with_cue_settings_is_dropped():
+    vtt = ("WEBVTT\n\n00:00:01.000 --> 00:00:03.000 align:start position:0% line:90%\n"
+           "<v Alice>Hi\n")
+    out = parse_vtt(vtt)
+    assert "align" not in out and "position" not in out and "-->" not in out
+    assert out == "Alice: Hi"
+
+
+# ---------- voice tag variants ----------
+def test_closing_voice_tag_is_stripped_not_leaked():
+    # The original parser's naive "<v ".replace + partition(">") left a trailing "</v>" on the
+    # utterance - prove that bug is fixed.
+    vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v Alice>Hello</v>\n"
+    assert parse_vtt(vtt) == "Alice: Hello"
+
+
+def test_voice_tag_with_single_class_is_handled():
+    vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v.loud Alice>Hi</v>\n"
+    assert parse_vtt(vtt) == "Alice: Hi"
+
+
+def test_voice_tag_with_multiple_classes_and_multiword_name_is_handled():
+    vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v.first.loud Bob Smith>Hey</v>\n"
+    assert parse_vtt(vtt) == "Bob Smith: Hey"
+
+
+def test_multiple_voice_spans_in_one_cue_produce_two_lines():
+    vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v Alice>Hi</v> <v Bob>Yo</v>\n"
+    assert parse_vtt(vtt) == "Alice: Hi\nBob: Yo"
+
+
+def test_empty_voice_tag_no_name_attributes_to_unknown_constant():
+    vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v>Hi</v>\n"
+    assert parse_vtt(vtt) == f"{UNKNOWN_SPEAKER}: Hi"
+
+
+def test_empty_voice_tag_with_space_no_name_attributes_to_unknown_constant():
+    vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v >Hi</v>\n"
+    assert parse_vtt(vtt) == f"{UNKNOWN_SPEAKER}: Hi"
+
+
+# ---------- inline cue tags / entities ----------
+def test_inline_styling_tags_are_stripped_but_words_kept():
+    vtt = ("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n"
+           "<v Alice>Hello <b>bold</b> <i>italic</i> <u>underline</u> "
+           "<c.highlight>styled</c> <ruby>base<rt>ann</rt></ruby> <lang en>lang</lang> end</v>\n")
+    out = parse_vtt(vtt)
+    assert out == "Alice: Hello bold italic underline styled base ann lang end"
+    for tag in ("<b>", "</b>", "<i>", "</i>", "<u>", "</u>", "<c.highlight>", "</c>",
+                "<ruby>", "</ruby>", "<rt>", "</rt>", "<lang en>", "</lang>"):
+        assert tag not in out
+
+
+def test_karaoke_inline_timestamps_are_removed():
+    vtt = ("WEBVTT\n\n00:00:01.000 --> 00:00:03.000\n"
+           "<v Alice>Hello <00:00:01.500> there <00:00:02.000> friend</v>\n")
+    out = parse_vtt(vtt)
+    assert "00:00:01.500" not in out and "00:00:02.000" not in out
+    assert out == "Alice: Hello there friend"
+
+
+def test_html_entities_are_decoded():
+    vtt = ("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n"
+           "<v Alice>Tom &amp; Jerry &lt;3&gt; &lrm;&rlm;done</v>\n")
+    out = parse_vtt(vtt)
+    assert out == "Alice: Tom & Jerry <3> ‎‏done"
+    assert "&amp;" not in out and "&lt;" not in out and "&gt;" not in out
+
+
+def test_nbsp_entity_decodes_to_real_nbsp_character():
+    vtt = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v Alice>A&nbsp;B</v>\n"
+    out = parse_vtt(vtt)
+    assert "&nbsp;" not in out
+    # &nbsp; decodes to a real U+00A0 - content the speaker "said" - so it must survive as
+    # the actual character, not be collapsed to a plain space. Pin the exact string (asserting
+    # merely that a plain space is present would pass vacuously via the "Alice: " prefix).
+    assert out == "Alice: A\xa0B"
+
+
+# ---------- multi-line payloads and cross-cue merging ----------
+def test_multiline_cue_payload_joins_under_one_speaker():
+    vtt = ("WEBVTT\n\n00:00:01.000 --> 00:00:04.000\n"
+           "<v Alice>This spans\nmultiple physical lines\nof one cue</v>\n")
+    assert parse_vtt(vtt) == "Alice: This spans multiple physical lines of one cue"
+
+
+def test_consecutive_cues_from_same_speaker_are_merged():
+    vtt = ("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v Alice>First part.\n\n"
+           "00:00:02.000 --> 00:00:03.000\n<v Alice>Second part.\n")
+    assert parse_vtt(vtt) == "Alice: First part. Second part."
+
+
+def test_different_speakers_are_not_merged():
+    vtt = ("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v Alice>Hi\n\n"
+           "00:00:02.000 --> 00:00:03.000\n<v Bob>Yo\n")
+    assert parse_vtt(vtt) == "Alice: Hi\nBob: Yo"
+
+
+# ---------- pre-flattened / non-VTT input ----------
+def test_preflattened_name_text_lines_are_preserved_not_double_prefixed():
+    out = parse_vtt("Alice: just do it\nBob: sounds good")
+    assert out == "Alice: just do it\nBob: sounds good"
+
+
+def test_non_vtt_arbitrary_text_never_raises_and_is_returned_sanely():
+    out = parse_vtt("just some random notes\nwith no structure at all")
+    assert out == "just some random notes\nwith no structure at all"
+
+
+def test_empty_string_input_returns_empty_string():
+    assert parse_vtt("") == ""
+
+
+def test_garbage_and_unbalanced_tags_never_raise():
+    garbage = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v Alice>unterminated <i>tag and <<<>>> junk\n"
+    out = parse_vtt(garbage)
+    assert isinstance(out, str)
+    # <i> is a well-formed inline tag and is stripped; the unbalanced <<<>>> junk is not a
+    # valid tag, so it is passed through verbatim rather than dropped or crashing.
+    assert out == "Alice: unterminated tag and <<<>>> junk"
+
+
+# ---------- line endings ----------
+def test_windows_crlf_line_endings_are_handled_with_no_cr_in_output():
+    vtt = "WEBVTT\r\n\r\n00:00:01.000 --> 00:00:02.000\r\n<v Alice>Hello\r\n"
+    out = parse_vtt(vtt)
+    assert "\r" not in out
+    assert out == "Alice: Hello"
+
+
+def test_stray_lone_cr_is_handled_with_no_cr_in_output():
+    vtt = "WEBVTT\r\n\r00:00:01.000 --> 00:00:02.000\r<v Alice>Hi\r"
+    out = parse_vtt(vtt)
+    assert "\r" not in out
+    assert out == "Alice: Hi"
+
+
+# ---------- fixture / regression parity with test_spine.py ----------
+def test_original_exact_equality_case_still_matches():
+    vtt = ("WEBVTT\n\n1\n00:00:01.000 --> 00:00:03.000\n<v Alice>Hello there\n\n"
+           "00:00:04.000 --> 00:00:05.000\n<v Bob>Hi Alice\n")
+    assert parse_vtt(vtt) == "Alice: Hello there\nBob: Hi Alice"
+
+
+def test_untagged_plain_line_case_still_matches():
+    assert parse_vtt("WEBVTT\n\n2\n00:00:01.000 --> 00:00:02.000\nplain line\n") == "plain line"
+
+
+# ---------- parse_transcript_segments helper, directly ----------
+def test_parse_transcript_segments_returns_speaker_none_for_unattributed_text():
+    segs = parse_transcript_segments("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nplain line\n")
+    assert segs == [(None, "plain line")]
+
+
+def test_parse_transcript_segments_returns_one_tuple_per_voice_span():
+    segs = parse_transcript_segments(
+        "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v Alice>Hi</v> <v Bob>Yo</v>\n")
+    assert segs == [("Alice", "Hi"), ("Bob", "Yo")]
+
+
+def test_parse_transcript_segments_never_raises_on_none_like_or_weird_input():
+    # Defensive: parse_vtt's contract is "never raises" even outside its typed str contract.
+    for bad in ("", "﻿", "<<<>>>", "NOTE\n\n", "STYLE\n\n"):
+        out = parse_vtt(bad)
+        assert isinstance(out, str)
+
+
+# ---------- adversarial-review regressions (production-hardening) ----------
+def test_unterminated_voice_tag_does_not_redos_hang():
+    # An unterminated "<v" followed by a long run of dots previously made the voice-tag regex
+    # backtrack exponentially and hang the whole pipeline forever (worse than raising, since the
+    # module's try/except cannot catch a runaway regex). Must now be linear and near-instant.
+    import time
+    start = time.perf_counter()
+    out = parse_vtt("<v" + "." * 500)
+    elapsed = time.perf_counter() - start
+    assert isinstance(out, str)
+    assert elapsed < 1.0  # fixed regex parses in microseconds; 1s is a huge, non-flaky margin
+
+
+def test_literal_arrow_inside_dialogue_is_not_mistaken_for_timing_and_dropped():
+    # "-->" can legitimately appear in what someone says. A bare substring test used to treat the
+    # whole utterance as a timing line and drop it; a real timestamp regex must keep it.
+    vtt = ("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v Alice>compare a --> b now</v>\n\n"
+           "00:00:05.000 --> 00:00:06.000\n<v Bob>after\n")
+    assert parse_vtt(vtt) == "Alice: compare a --> b now\nBob: after"
+
+
+def test_bare_style_keyword_as_cue_id_before_timing_line_keeps_dialogue():
+    # A bare "STYLE" sitting where a cue identifier goes (immediately before a real timing line)
+    # must be treated as a cue id, not a STYLE metadata block - otherwise the block-skip ate the
+    # timing line and the dialogue with it.
+    vtt = "WEBVTT\n\nSTYLE\n00:00:01.000 --> 00:00:02.000\n<v Alice>Hi\n"
+    assert parse_vtt(vtt) == "Alice: Hi"
+
+
+def test_genuine_style_block_body_is_still_dropped():
+    # ...but a real STYLE block (keyword followed by its body, not a timing line) is still dropped.
+    vtt = ("WEBVTT\n\nSTYLE\n::cue { color: red }\n\n"
+           "00:00:01.000 --> 00:00:02.000\n<v Alice>Hi\n")
+    assert parse_vtt(vtt) == "Alice: Hi"
+
+
+def test_two_different_anonymous_speakers_are_not_merged():
+    # Two distinct unnamed <v> cues both attribute to "Unknown", but they are different people -
+    # the same-speaker merge must NOT fuse them into one continuous turn.
+    vtt = ("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n<v>first anon</v>\n\n"
+           "00:00:03.000 --> 00:00:04.000\n<v>second anon</v>\n")
+    assert parse_vtt(vtt) == "Unknown: first anon\nUnknown: second anon"

--- a/agent/tests/test_spine.py
+++ b/agent/tests/test_spine.py
@@ -1,0 +1,236 @@
+"""Unit tests for the Preppie spine. No network: the backend and the LLM client are injected."""
+import json
+import os
+import types
+
+from agent.spine import parse_vtt, read_transcript, Backend, run_spine
+
+
+# ---------- transcript parsing ----------
+def test_parse_vtt_extracts_speakers():
+    vtt = ("WEBVTT\n\n1\n00:00:01.000 --> 00:00:03.000\n<v Alice>Hello there\n\n"
+           "00:00:04.000 --> 00:00:05.000\n<v Bob>Hi Alice\n")
+    assert parse_vtt(vtt) == "Alice: Hello there\nBob: Hi Alice"
+
+
+def test_parse_vtt_keeps_untagged_lines_and_drops_noise():
+    assert parse_vtt("WEBVTT\n\n2\n00:00:01.000 --> 00:00:02.000\nplain line\n") == "plain line"
+
+
+def test_read_transcript_plain_file_is_verbatim(tmp_path):
+    p = tmp_path / "notes.txt"
+    p.write_text("Alice: just do it")
+    assert read_transcript(str(p)) == "Alice: just do it"
+
+
+def test_sample_fixture_parses():
+    fixture = os.path.join(os.path.dirname(__file__), "fixtures", "sample-meeting.vtt")
+    out = read_transcript(fixture)
+    assert "Priya Sharma:" in out and "Daniel Okoro:" in out and "-->" not in out
+
+
+# ---------- backend dispatch ----------
+class _FakeResp:
+    def __init__(self, body):
+        self._b = json.dumps(body).encode()
+
+    def read(self):
+        return self._b
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
+def test_backend_dispatch_injects_project_and_posts():
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["url"] = req.full_url
+        seen["method"] = req.get_method()
+        seen["body"] = json.loads(req.data.decode()) if req.data else None
+        return _FakeResp({"success": True, "count": 0})
+
+    Backend("https://backend.example/", "MyProj", opener=opener).dispatch(
+        "search_work_items", {"titleContains": "foo"})
+    assert seen["url"].endswith("/api/search_work_items")
+    assert seen["method"] == "POST"
+    assert seen["body"] == {"project": "MyProj", "titleContains": "foo"}
+
+
+def test_backend_read_projects_is_get_no_body():
+    def opener(req, timeout=None):
+        assert req.get_method() == "GET"
+        assert req.data is None
+        return _FakeResp({"success": True, "projects": []})
+
+    Backend("https://b", "P", opener=opener).dispatch("read_projects", {})
+
+
+def test_backend_retries_transient_connection_error(monkeypatch):
+    import urllib.error
+    monkeypatch.setattr("agent.spine.time.sleep", lambda *_: None)  # no real backoff in tests
+    calls = {"n": 0}
+
+    def flaky_opener(req, timeout=None):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise urllib.error.URLError("connection refused")
+        return _FakeResp({"success": True, "count": 0})
+
+    out = Backend("https://b", "P", opener=flaky_opener).dispatch("search_work_items", {})
+    assert out["success"] is True and calls["n"] == 3  # failed twice, succeeded on the third
+
+
+def test_backend_gives_up_after_attempts(monkeypatch):
+    import urllib.error
+    monkeypatch.setattr("agent.spine.time.sleep", lambda *_: None)
+
+    def always_refuse(req, timeout=None):
+        raise urllib.error.URLError("refused")
+
+    out = Backend("https://b", "P", opener=always_refuse, attempts=3).dispatch("read_projects", {})
+    assert out["success"] is False and "connection error" in out["error"]
+
+
+def test_backend_dispatch_project_cannot_be_overridden_by_args():
+    # The backend's guarantee is that every call is scoped to Backend.project. If the model's
+    # tool-call arguments ever contained a stray "project" key, it must not win over that.
+    seen = {}
+
+    def opener(req, timeout=None):
+        seen["body"] = json.loads(req.data.decode())
+        return _FakeResp({"success": True})
+
+    Backend("https://b", "RealProject", opener=opener).dispatch(
+        "create_work_item", {"type": "Task", "title": "t", "description": "d", "project": "Hijacked"})
+    assert seen["body"]["project"] == "RealProject"
+
+
+# ---------- the run loop ----------
+def _fcall(name, args, call_id):
+    return types.SimpleNamespace(type="function_call", name=name,
+                                 arguments=json.dumps(args), call_id=call_id)
+
+
+class _FakeClient:
+    """Replays a scripted list of (output_items, output_text) responses."""
+
+    def __init__(self, scripted):
+        self._scripted = list(scripted)
+        self._n = 0
+        self.calls = []
+        self.responses = self
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        out, text = self._scripted[self._n]
+        self._n += 1
+        return types.SimpleNamespace(output=out, output_text=text, id=f"resp_{self._n}")
+
+
+class _FakeBackend:
+    def __init__(self):
+        self.dispatched = []
+        self._next_id = 100
+
+    def dispatch(self, name, args):
+        self.dispatched.append((name, args))
+        if name == "create_work_item":
+            self._next_id += 1
+            return {"success": True, "work_item_id": self._next_id,
+                    "work_item_type": args["type"], "title": args["title"], "url": "http://x"}
+        if name == "search_work_items":
+            return {"success": True, "count": 0, "workItems": []}
+        return {"success": True}
+
+
+def test_run_spine_dedupes_before_create_and_collects_results():
+    scripted = [
+        ([_fcall("search_work_items", {"titleContains": "Portal"}, "c1"),
+          _fcall("create_work_item", {"type": "Epic", "title": "Portal", "description": "d"}, "c2")], ""),
+        ([], "done: logged 1 item"),
+    ]
+    client, backend = _FakeClient(scripted), _FakeBackend()
+    result = run_spine("Alice: build a portal", "INSTR", client, backend, "gpt-x")
+
+    names = [n for n, _ in backend.dispatched]
+    assert names.index("search_work_items") < names.index("create_work_item")  # dedupe first
+    assert len(result["created"]) == 1
+    assert result["created"][0]["title"] == "Portal"
+    assert result["reply_back"] == "done: logged 1 item"
+    # tool outputs were fed back referencing the prior response id
+    assert client.calls[1].get("previous_response_id") == "resp_1"
+
+
+def test_run_spine_terminates_at_max_turns():
+    forever = ([_fcall("search_work_items", {}, "c")], "")
+    result = run_spine("t", "i", _FakeClient([forever] * 50), _FakeBackend(), "m", max_turns=5)
+    assert result["turns"] == 5
+    # the model never produced a final text reply (it kept calling tools) - the caller must still
+    # get a non-blank explanation rather than silently seeing an empty reply-back.
+    assert result["reply_back"] and "5 turns" in result["reply_back"]
+
+
+def test_run_spine_handles_malformed_tool_arguments_without_crashing():
+    scripted = [
+        ([types.SimpleNamespace(type="function_call", name="create_work_item",
+                                arguments="{not valid json", call_id="c1")], ""),
+        ([], "done"),
+    ]
+    client, backend = _FakeClient(scripted), _FakeBackend()
+    result = run_spine("t", "i", client, backend, "m")
+    # the bad call must never reach the backend, but the loop must still feed an output back
+    # (referencing the same call_id) so the model isn't left hanging, and the run completes.
+    assert backend.dispatched == []
+    assert result["reply_back"] == "done"
+    second_call_outputs = client.calls[1]["input"]
+    assert second_call_outputs[0]["call_id"] == "c1"
+    assert json.loads(second_call_outputs[0]["output"])["success"] is False
+
+
+def test_run_spine_handles_non_object_tool_arguments():
+    scripted = [
+        ([types.SimpleNamespace(type="function_call", name="search_work_items",
+                                arguments="[1, 2, 3]", call_id="c1")], ""),
+        ([], "done"),
+    ]
+    result = run_spine("t", "i", _FakeClient(scripted), _FakeBackend(), "m")
+    assert result["reply_back"] == "done"
+
+
+class _FailingCreateBackend:
+    """A backend whose create_work_item always fails, to check the loop doesn't leave the model
+    hanging (every call_id still needs a function_call_output) or lose track of the run."""
+
+    def __init__(self):
+        self.dispatched = []
+
+    def dispatch(self, name, args):
+        self.dispatched.append((name, args))
+        return {"success": False, "error": "Azure DevOps rejected the request"}
+
+
+def test_run_spine_feeds_output_back_after_failed_create():
+    scripted = [
+        ([_fcall("create_work_item", {"type": "Task", "title": "T", "description": "d"}, "c1")], ""),
+        ([], "done: 0 items logged"),
+    ]
+    client = _FakeClient(scripted)
+    result = run_spine("t", "i", client, _FailingCreateBackend(), "m")
+
+    assert result["created"] == []  # nothing to show for a failed create
+    assert result["reply_back"] == "done: 0 items logged"  # the loop still completed normally
+    fed_back = client.calls[1]["input"]
+    assert fed_back[0]["call_id"] == "c1"
+    assert json.loads(fed_back[0]["output"])["success"] is False
+
+
+def test_run_spine_records_events():
+    events = []
+    scripted = [([_fcall("create_work_item", {"type": "Task", "title": "T", "description": "d"}, "c1")], ""),
+                ([], "ok")]
+    run_spine("t", "i", _FakeClient(scripted), _FakeBackend(), "m", on_event=events.append)
+    assert any("create Task" in e for e in events)

--- a/src/function_app.py
+++ b/src/function_app.py
@@ -287,8 +287,11 @@ def create_work_item(req: func.HttpRequest) -> func.HttpResponse:
                 mimetype="application/json"
             )
 
-        # Extract metadata from description if present (speaker, timestamp, meeting ID)
-        tags = []
+        # Tags carry the T-Minus-15 triage type when the process template has no native
+        # work item type for it (e.g. Enhancement -> Task+tag, Risk/Question -> Issue+tag).
+        tags = req_body.get("tags") or []
+        if isinstance(tags, str):
+            tags = [t.strip() for t in tags.split(";") if t.strip()]
         custom_fields = {}
 
         # Get DevOps client and create work item


### PR DESCRIPTION
## Summary

Replaces the naive VTT parser in the spine with a production-grade one, so **who said what** survives
contact with real Teams transcripts. Speaker attribution is what makes "Sam raised this" /
"Daniel owns this" work on the resulting work items — if the parser mis-attributes, every downstream
owner and raiser is wrong.

The original parser assumed one clean `<v Name>text</v>` per cue. Real transcripts aren't that tidy.

## Issues Addressed

Related to #67, but explicitly **not** a fix for it — #67 is Azure Speech Services diarization in the
media-bot path, a different pipeline. It is an argument for the Graph transcript path though: there,
speaker identity comes from Teams' own voice tags rather than being inferred from audio, so this
class of bug doesn't arise.

## Key decisions (calling these out for review)

1. **Two-stage parse, not one regex.** `parse_transcript_segments` (a state machine over the cue
   structure) → `_merge_consecutive_speakers` → flatten. Keeping segmentation and merging separate is
   what makes the edge cases testable individually.

2. **Merge consecutive same-speaker cues.** Teams splits a single continuous utterance across many
   cues; without merging, the agent sees a stream of fragments instead of a thought, and triage
   quality drops.

3. **Never merge anonymous speakers.** Two `Unknown` runs are not evidence of the same person, so
   `UNKNOWN_SPEAKER` is explicitly excluded from the merge — otherwise unrelated speech gets welded
   into one attributed block.

## Key Changes

- `agent/spine.py` — `parse_transcript_segments`, `_merge_consecutive_speakers`, `_split_voice_spans`,
  `_clean_cue_text`, module-level compiled regexes.
- `agent/tests/test_parse.py` — 39 parser tests.

Handles: voice-tag classes (`<v.loud Name>`), stray `</v>`, multi-line cues, consecutive-same-speaker
merging, `NOTE`/`STYLE`/`REGION` blocks, BOM, CRLF, HTML entities, karaoke timestamps
(`<00:00:01.500>`), and empty `<v>` → `Unknown`.

## Robustness

Adversarial review caught a **blocker: catastrophic backtracking (ReDoS)**. An unterminated `<v`
followed by a run of dots drove the voice-tag regex exponential — the parse hangs **forever**, and
because it's regex-internal, no `try`/`except` or outer timeout in the calling code can rescue it. A
malformed transcript would have taken the whole run down with no error. Fixed by tightening the
character class to `[^ \t>.]+`.

Three more found and fixed:

- A literal `-->` inside dialogue was being mistaken for a timing line and the text dropped — both
  the timing-line branch and the cue-id lookahead now use a real timestamp regex (`_TIMING_RE`).
- A cue whose text began with the word `NOTE` or `STYLE` was eaten as a metadata block — now only
  skipped when the next line **isn't** a real timing line.
- Two distinct anonymous speakers merging into one (see decision 3).

## Known limitations / follow-up

- Attribution is only as good as what Teams puts in the voice tags — guests without a resolved
  display name still land as `Unknown`.
- Non-Teams VTT dialects (WebVTT from other tools) aren't specifically targeted; they parse, but
  speaker extraction depends on the `<v>` convention.

## Test Plan

- [x] `python -m pytest agent/tests/ -q` → **54 passing** (39 new parser tests), no network —
      including explicit regression tests for the ReDoS input, the `-->`-in-dialogue case, the
      `NOTE`-prefixed cue, and anonymous-speaker merging.
- [x] Exercised against the real Teams transcript from the live meeting run (`<v Ayush Bisht>` voice
      tags) — attribution correct end-to-end through to work-item owners.

```bash
python -m pytest agent/tests/ -q
```

## Note on branching

Branches off `feat/foundry-spine` (#78), so the diff is cleanest once that's merged — happy to
rebase onto `main` as soon as it goes in.

## Note on CI

The red checks are **fork-PR limits, not this code**: the Claude review action can't get an OIDC
token on PRs from forks, and `test.yml`'s "Comment PR" step can't post from a fork's read-only
token. The actual build/lint/test jobs pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
