### PR TITLE
ci: make workflows fork-safe (green on fork PRs) + wire in Python agent tests

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,12 @@ on:
 
 jobs:
   claude-review:
+    # Only run for same-repo PRs. PRs from forks don't receive repo secrets or
+    # an OIDC token by design, so this job can't authenticate and would fail with
+    # "Could not fetch an OIDC token". Skipping (rather than failing) keeps fork
+    # PRs green; a maintainer can review those from a same-repo branch.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,6 +97,34 @@ jobs:
           flags: unittests
           name: codecov-umbrella
 
+  python-tests:
+    name: Python Agent Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Run agent unit tests
+        # Self-activating: the agent/ package and its tests arrive with the
+        # Foundry-spine PR. Until then this job is a no-op so it stays green on
+        # main; once the tests are present it runs the real pytest suite.
+        run: |
+          if ls agent/tests/test_*.py >/dev/null 2>&1; then
+            echo "Agent tests found — installing deps and running pytest."
+            python -m pip install --upgrade pip
+            [ -f requirements.txt ] && pip install -r requirements.txt
+            pip install pytest
+            pytest agent/tests/ -q
+          else
+            echo "No agent tests present yet (they land with the spine PR); skipping."
+          fi
+
   validate-bicep:
     name: Validate Bicep Templates
     runs-on: ubuntu-latest
@@ -154,28 +182,44 @@ jobs:
   test-summary:
     name: Test Summary
     runs-on: ubuntu-latest
-    needs: [lint, build-bot, unit-tests, validate-bicep]
+    needs: [lint, build-bot, unit-tests, python-tests, validate-bicep]
     if: always()
 
     steps:
+      - name: Write results to job summary
+        # $GITHUB_STEP_SUMMARY is always writable, including on PRs from forks,
+        # so results are visible in the run UI regardless of token scope.
+        run: |
+          {
+            echo "## Test Results"
+            echo ""
+            echo "| Job | Result |"
+            echo "| --- | ------ |"
+            echo "| Lint | ${{ needs.lint.result }} |"
+            echo "| Build | ${{ needs.build-bot.result }} |"
+            echo "| Unit Tests (.NET) | ${{ needs.unit-tests.result }} |"
+            echo "| Python Agent Tests | ${{ needs.python-tests.result }} |"
+            echo "| Bicep Validation | ${{ needs.validate-bicep.result }} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Check test results
         run: |
           # Check if any required job failed
           LINT="${{ needs.lint.result }}"
           BUILD="${{ needs.build-bot.result }}"
           TESTS="${{ needs.unit-tests.result }}"
+          PYTESTS="${{ needs.python-tests.result }}"
           BICEP="${{ needs.validate-bicep.result }}"
 
-          # Bicep validation is optional - treat skipped as success
-          if [[ "$BICEP" == "skipped" ]]; then
-            echo "ℹ️ Bicep validation skipped (Azure credentials not configured)"
-            BICEP="success"
-          fi
+          # Optional jobs - treat skipped as success
+          [[ "$BICEP" == "skipped" ]] && BICEP="success"
+          [[ "$PYTESTS" == "skipped" ]] && PYTESTS="success"
 
           # Fail if any job failed
           if [[ "$LINT" == "failure" ]] || \
              [[ "$BUILD" == "failure" ]] || \
              [[ "$TESTS" == "failure" ]] || \
+             [[ "$PYTESTS" == "failure" ]] || \
              [[ "$BICEP" == "failure" ]]; then
             echo "❌ Tests failed"
             exit 1
@@ -184,7 +228,14 @@ jobs:
           fi
 
       - name: Comment PR
-        if: github.event_name == 'pull_request'
+        # Only same-repo PRs get a write-scoped token; a fork PR's token is
+        # read-only, so posting a comment would 403 ("Resource not accessible
+        # by integration") and fail the job. Skip it for forks — the job
+        # summary above already carries the results for everyone.
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         uses: actions/github-script@v7
         with:
           script: |
@@ -193,7 +244,8 @@ jobs:
 
             - Lint: ${{ needs.lint.result }}
             - Build: ${{ needs.build-bot.result }}
-            - Unit Tests: ${{ needs.unit-tests.result }}
+            - Unit Tests (.NET): ${{ needs.unit-tests.result }}
+            - Python Agent Tests: ${{ needs.python-tests.result }}
             - Bicep Validation: ${{ needs.validate-bicep.result }}
             `;
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -117,10 +117,12 @@ jobs:
         run: |
           if ls agent/tests/test_*.py >/dev/null 2>&1; then
             echo "Agent tests found — installing deps and running pytest."
+            # Use `python -m pip`/`python -m pytest` throughout so installs and
+            # execution always target the interpreter actions/setup-python configured.
             python -m pip install --upgrade pip
-            [ -f requirements.txt ] && pip install -r requirements.txt
-            pip install pytest
-            pytest agent/tests/ -q
+            [ -f requirements.txt ] && python -m pip install -r requirements.txt
+            python -m pip install pytest
+            python -m pytest agent/tests/ -q
           else
             echo "No agent tests present yet (they land with the spine PR); skipping."
           fi
@@ -204,7 +206,6 @@ jobs:
 
       - name: Check test results
         run: |
-          # Check if any required job failed
           LINT="${{ needs.lint.result }}"
           BUILD="${{ needs.build-bot.result }}"
           TESTS="${{ needs.unit-tests.result }}"
@@ -215,12 +216,20 @@ jobs:
           [[ "$BICEP" == "skipped" ]] && BICEP="success"
           [[ "$PYTESTS" == "skipped" ]] && PYTESTS="success"
 
-          # Fail if any job failed
-          if [[ "$LINT" == "failure" ]] || \
-             [[ "$BUILD" == "failure" ]] || \
-             [[ "$TESTS" == "failure" ]] || \
-             [[ "$PYTESTS" == "failure" ]] || \
-             [[ "$BICEP" == "failure" ]]; then
+          # Require an explicit 'success' for every required job. Checking only
+          # for 'failure' would let other non-success results (notably
+          # 'cancelled' from a manual cancel, runner loss, or concurrency) slip
+          # through as a pass, so gate on != success instead.
+          FAILED=0
+          for job in "lint=$LINT" "build=$BUILD" "unit-tests=$TESTS" \
+                     "python-tests=$PYTESTS" "bicep=$BICEP"; do
+            if [[ "${job#*=}" != "success" ]]; then
+              echo "❌ ${job%%=*} did not succeed (result: ${job#*=})"
+              FAILED=1
+            fi
+          done
+
+          if [[ "$FAILED" == "1" ]]; then
             echo "❌ Tests failed"
             exit 1
           else


### PR DESCRIPTION
## Summary

Makes the repo's CI **green on PRs from forks** and adds a real Python test job.

The red ✗ that's been showing on the recent PRs was never the code — it was two workflow steps
hitting GitHub's fork-PR security model (forks don't get repo secrets or a write-scoped
`GITHUB_TOKEN`). This fixes both at the source, so external contributors' PRs go green instead of
red, and adds the `pytest` job we discussed.

## What was going red, and why

1. **`Claude Code Review`** — failed with *"Could not fetch an OIDC token."* The action needs a repo
   secret (`CLAUDE_CODE_OAUTH_TOKEN`) and an OIDC token; GitHub withholds both from fork PRs by
   design. Nothing to do with the diff — it died before reading any code (the trivial rename PR
   failed it identically).

2. **`Test Pennie` → `Test Summary`** — the real jobs (Lint, Build, Unit Tests) **all passed**. The
   failure was the **`Comment PR` step**: it posts results with `github.rest.issues.createComment`,
   which 403s (*"Resource not accessible by integration"*) under a fork's read-only token, failing
   the whole job. The tests didn't fail — *posting a comment about the passing tests* did.

## Changes

**`claude-code-review.yml`**
- Gate the job to same-repo PRs: `if: github.event.pull_request.head.repo.full_name == github.repository`.
  Fork PRs now **skip** it (grey) instead of failing (red). A maintainer can still run the review from
  a same-repo branch.

**`test.yml`**
- **Results always go to `$GITHUB_STEP_SUMMARY`** — a new step writes a results table there. That
  surface is writable even on fork PRs, so everyone sees the outcome in the run UI regardless of
  token scope.
- **`Comment PR` is now gated to same-repo PRs and `continue-on-error: true`** — so a fork PR skips it
  cleanly, and even an unexpected comment failure can't fail the job.
- **New `Python Agent Tests` job** running `pytest agent/tests/`. It's **self-activating**: while the
  `agent/` package lives on the spine PR (#78) it's a no-op (stays green on `main`), and it runs the
  real suite automatically the moment those tests land on `main`. Wired into the `Test Summary` gate,
  with `skipped` treated as success.

## Why gate rather than use `pull_request_target`

`pull_request_target` would let fork PRs access secrets, but it runs in the **base repo's** context
with write permissions against **untrusted fork code** — a well-known security footgun. Gating to
same-repo PRs is the safe, conventional choice; it just means secret-dependent checks don't run on
forks (which is the correct security posture anyway).

## Test Plan

- [x] Both workflows parse (`yaml.safe_load`), and `Test Summary` correctly `needs` the new
      `python-tests` job.
- [x] The `Python Agent Tests` guard verified in `bash`: with no `agent/tests/test_*.py` present (as
      on `main`) it prints "skipping" and exits 0 → job green; when those files exist it runs pytest.
- [x] Scoped to `.github/workflows/` only — no application code touched.

Follow-up once merged: the same-repo gating means these checks will run fully on branches pushed to
this repo. If you'd like, I can also bump the actions still on Node 20 (checkout/setup-*) to silence
the deprecation warnings — kept out of here to keep the PR tight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
